### PR TITLE
增加 ai tag 功能 0.0.18

### DIFF
--- a/ai.ts
+++ b/ai.ts
@@ -1,0 +1,114 @@
+import { requestUrl, Notice } from 'obsidian';
+import { MowenPluginSettings } from './settings';
+
+// 定义AI服务返回的数据结构
+export interface AIGeneratedContent {
+    title: string;
+    tags: string[]; // 标签数组
+    summary?: string; // 摘要是可选的
+}
+
+// 定义不同AI服务商的配置
+interface LLMProvider {
+    generate(apiKey: string, model: string, content: string, generateSummary: boolean, tagsCount: number): Promise<AIGeneratedContent>;
+}
+
+// DeepSeek的实现
+class DeepSeekProvider implements LLMProvider {
+    async generate(apiKey: string, model: string, content: string, generateSummary: boolean, tagsCount: number): Promise<AIGeneratedContent> {
+        const url = 'https://api.deepseek.com/chat/completions';
+        
+        // 根据是否需要摘要，动态构建系统提示
+        const summaryInstruction = generateSummary
+            ? "3. 生成一段不超过200字的中文内容摘要。"
+            : "";
+        const jsonKeys = generateSummary
+            ? "'title' (字符串), 'tags' (字符串数组), 和 'summary' (字符串)"
+            : "'title' (字符串) 和 'tags' (字符串数组)";
+        const example = generateSummary
+            ? `{"title": "笔记标题", "tags": ["标签1", "标签2"], "summary": "这是摘要内容..."}`
+            : `{"title": "笔记标题", "tags": ["标签1", "标签2"]}`;
+
+        const system_prompt = `你是一位专业的笔记处理助手。请根据用户提供的笔记内容，完成以下任务：
+1.  生成一个简洁、精炼的笔记标题。
+2.  提取${tagsCount}个最相关的关键词作为标签。
+${summaryInstruction}
+
+请将结果以一个纯粹的、不含任何额外解释和 markdown 格式的 JSON 对象形式返回，该对象必须包含以下键：${jsonKeys}。
+例如: ${example}`;
+
+        const requestBody = {
+            model: model,
+            messages: [
+                { "role": "system", "content": system_prompt },
+                { "role": "user", "content": content }
+            ],
+            stream: false,
+            response_format: { type: "json_object" }
+        };
+
+        try {
+            // 在请求前打印日志
+            console.log('DeepSeek API Request URL:', url);
+            console.log('DeepSeek API Request Body:', JSON.stringify(requestBody, null, 2));
+
+            const response = await requestUrl({
+                url: url,
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify(requestBody),
+            });
+
+            // 在收到响应后打印日志
+            console.log('DeepSeek API Response:', response);
+
+            const data = response.json;
+            if (data.choices && data.choices.length > 0) {
+                const resultText = data.choices[0].message.content;
+                // 尝试解析返回的JSON字符串
+                const parsedResult: AIGeneratedContent = JSON.parse(resultText);
+                return parsedResult;
+            } else {
+                throw new Error('API未返回有效内容');
+            }
+        } catch (error) {
+            console.error('DeepSeek API 请求失败:', error);
+            new Notice(`AI 生成失败: ${error.message}`);
+            throw error;
+        }
+    }
+}
+
+// 工厂函数，根据provider选择对应的实现
+function getProvider(providerName: string): LLMProvider {
+    switch (providerName) {
+        case 'deepseek':
+            return new DeepSeekProvider();
+        // 在这里可以扩展其他服务商，例如:
+        // case 'kimi':
+        //     return new KimiProvider();
+        default:
+            throw new Error(`不支持的 AI 服务商: ${providerName}`);
+    }
+}
+
+export async function generateNoteMetadata(settings: MowenPluginSettings, content: string): Promise<AIGeneratedContent | null> {
+    const { provider, apiKey, model, generateSummary, tagsCount } = settings.llmSettings;
+
+    if (!provider || !apiKey || !model) {
+        new Notice('请先在设置中完成 AI 配置');
+        return null;
+    }
+
+    try {
+        const llmProvider = getProvider(provider);
+        const result = await llmProvider.generate(apiKey, model, content, generateSummary, tagsCount);
+        return result;
+    } catch (error) {
+        // 错误已在具体实现中处理和通知
+        return null;
+    }
+} 

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "publish-note-to-mowen",
 	"name": "Publish Note to Mowen Note",
-	"version": "0.0.16",
+	"version": "0.0.17",
 	"minAppVersion": "0.15.0",
 	"description": "Publish note to Mowen note mini program.",
 	"author": "ziyou",

--- a/settings.ts
+++ b/settings.ts
@@ -1,16 +1,33 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import MowenPlugin from "./main";
 
+// 定义 LLM 设置的接口
+export interface LLMSettings {
+  provider: 'deepseek'; // 未来可扩展为 'deepseek' | 'kimi' | 'openai'
+  apiKey: string;
+  model: string;
+  generateSummary: boolean; // 添加生成摘要的开关
+  tagsCount: number; // AI生成标签的数量
+}
+
 export interface MowenPluginSettings {
   apiKey: string;
   autoPublish: boolean;
   defaultTag: string;
+  llmSettings: LLMSettings; // 添加 LLM 设置
 }
 
 export const DEFAULT_SETTINGS: MowenPluginSettings = {
   apiKey: "",
-  autoPublish: false,
+  autoPublish: true,
   defaultTag: "Obsidian",
+  llmSettings: {
+    provider: 'deepseek',
+    apiKey: '',
+    model: 'deepseek-chat', // DeepSeek 默认模型
+    generateSummary: false, // 默认不生成摘要
+    tagsCount: 3 // 默认生成3个标签
+  },
 };
 
 export class MowenSettingTab extends PluginSettingTab {
@@ -24,44 +41,104 @@ export class MowenSettingTab extends PluginSettingTab {
   display(): void {
     const { containerEl } = this;
     containerEl.empty();
-    containerEl.createEl("h2", { text: "Mowen API 设置" });
+
+    // 墨问发布设置
+    containerEl.createEl('h2', { text: '墨问发布设置' });
 
     new Setting(containerEl)
-      .setName("API-KEY")
-      .setDesc("你的墨问 API-KEY")
-      .addText(text =>
-        text
-          .setPlaceholder("输入 API-KEY")
-          .setValue(this.plugin.settings.apiKey)
-          .onChange(async (value) => {
-            this.plugin.settings.apiKey = value;
-            await this.plugin.saveSettings();
-          })
-      );
+      .setName('API-KEY')
+      .setDesc('请输入你的墨问 API-KEY')
+      .addText(text => text
+        .setPlaceholder('Enter your API-KEY')
+        .setValue(this.plugin.settings.apiKey)
+        .onChange(async (value) => {
+          this.plugin.settings.apiKey = value;
+          await this.plugin.saveSettings();
+        }));
 
     new Setting(containerEl)
-      .setName("自动发布")
-      .setDesc("开启后，弹窗默认勾选自动发布")
-      .addToggle(toggle =>
-        toggle
-          .setValue(this.plugin.settings.autoPublish)
-          .onChange(async (value) => {
-            this.plugin.settings.autoPublish = value;
-            await this.plugin.saveSettings();
-          })
-      );
+      .setName('默认标签')
+      .setDesc('发布到墨问笔记中默认的标签，多个标签用英文逗号分隔')
+      .addText(text => text
+        .setValue(this.plugin.settings.defaultTag)
+        .onChange(async (value) => {
+          this.plugin.settings.defaultTag = value;
+          await this.plugin.saveSettings();
+        }));
 
     new Setting(containerEl)
-      .setName("默认标签")
-      .setDesc("发布时自动附加的默认标签（如 Obsidian）")
-      .addText(text =>
-        text
-          .setPlaceholder("Obsidian")
-          .setValue(this.plugin.settings.defaultTag)
-          .onChange(async (value) => {
-            this.plugin.settings.defaultTag = value;
+      .setName('自动发布')
+      .setDesc('发布后是否自动发布到墨问，默认是发布到墨问笔记中，但不是发布状态')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.autoPublish)
+        .onChange(async (value) => {
+          this.plugin.settings.autoPublish = value;
+          await this.plugin.saveSettings();
+        }));
+
+    // AI 功能设置
+    containerEl.createEl('h2', { text: 'AI 功能设置' });
+
+    new Setting(containerEl)
+      .setName('AI 服务商')
+      .setDesc('选择用于生成标题和标签的AI服务')
+      .addDropdown(dropdown => {
+        dropdown
+          .addOption('deepseek', 'DeepSeek')
+          //未来在这里添加更多选项
+          .setValue(this.plugin.settings.llmSettings.provider)
+          .onChange(async (value: 'deepseek') => {
+            this.plugin.settings.llmSettings.provider = value;
             await this.plugin.saveSettings();
-          })
-      );
+            this.display(); // 重新渲染以显示或隐藏相关设置
+          });
+      });
+
+    new Setting(containerEl)
+      .setName('API Key')
+      .setDesc('请输入所选 AI 服务商的 API Key')
+      .addText(text => text
+        .setPlaceholder('在此输入 API Key')
+        .setValue(this.plugin.settings.llmSettings.apiKey)
+        .onChange(async (value) => {
+          this.plugin.settings.llmSettings.apiKey = value;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName('模型名称')
+      .setDesc('指定要使用的模型，例如 deepseek-chat')
+      .addText(text => text
+        .setPlaceholder('例如 deepseek-chat')
+        .setValue(this.plugin.settings.llmSettings.model)
+        .onChange(async (value) => {
+          this.plugin.settings.llmSettings.model = value;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName('生成摘要')
+      .setDesc('开启后，AI 将在生成标题和标签的同时生成内容摘要，摘要内容会随文章发布到墨问笔记中，在墨问笔记中会显示在笔记标题下方引用块中')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.llmSettings.generateSummary)
+        .onChange(async (value) => {
+          this.plugin.settings.llmSettings.generateSummary = value;
+          await this.plugin.saveSettings();
+        }));
+    
+    new Setting(containerEl)
+      .setName('生成标签数量')
+      .setDesc('指定 AI 生成标签的数量 (1-5)')
+      .addDropdown(dropdown => {
+        for (let i = 1; i <= 5; i++) {
+          dropdown.addOption(String(i), String(i));
+        }
+        dropdown
+          .setValue(String(this.plugin.settings.llmSettings.tagsCount))
+          .onChange(async (value) => {
+            this.plugin.settings.llmSettings.tagsCount = parseInt(value, 10);
+            await this.plugin.saveSettings();
+          });
+      });
   }
 }


### PR DESCRIPTION
>[!quote] 一言
 你想走，就请立马抽刀，爱一笔勾销。  —— 《缘分一道桥》 · 方文山

### 🎉 墨问插件更新：AI 智能助手 & 体验优化 (0.0.18)

本次更新在 0.0.18 版本上引入了强大的 AI 辅助功能，旨在大幅提升创建和发布笔记的效率。同时也对核心功能和用户体验进行了多项重要改进和优化。

### ✨ 新增功能 (Features)

#### 引入 AI 智能助手，赋能笔记创作

- 智能生成标题与标签：在发布弹窗中新增“✨ AI 生成”按钮，可一键调用大模型 API，根据笔记内容自动生成精炼的标题和精准的标签，并填充到输入框。
- 按需生成内容摘要：可在设置中开启“生成摘要”功能。开启后，AI 会在生成元数据的同时，为您提炼一段内容摘要，并自动以引用块的形式添加到发布笔记的标题下方。
- 灵活的 AI 服务配置：
- 新增独立的“AI 功能设置”区域，集中管理所有 AI 相关选项。
- 初步支持 DeepSeek 大模型，并为未来扩展更多服务商（如 Kimi, OpenAI 等）提供了良好的架构。
- 用户可自由配置 API Key 和所使用的模型名称。
- 用户可通过下拉菜单在 1-5 个之间，自定义 AI 生成标签的数量，默认为 3 个。
![[插件设置.png]]
![[发布弹窗.png]]
#### 🚀 优化与改进 (Optimizations & Improvements)

#### 设置页面结构重构

- 为了更清晰的用户体验，我们将设置页面重构为“墨问发布设置”和“AI 功能设置”两大模块，让配置逻辑更清晰。

#### 发布弹窗预览更精准

- 当 AI 生成摘要后，发布弹窗中的“内容”预览区会立即同步更新，将摘要内容展示在最前方，确保预览与最终发布的内容完全一致。
- 更强大的内链识别能力：重构了对 `[[...]]` 和 `![[...]]` 语法的解析逻辑，现在可以非常可靠地处理不带文件后缀的笔记或图片链接，大幅提升了对 Obsidian 内置链接语法的兼容性。

### 🐛 Bug 修复 (Bug Fixes)

- 修复了之前版本中，当笔记内嵌链接（如 `[[我的笔记]]` 或 `![[图片]]）`不包含文件扩展名时，可能无法正确识别文件并进行处理的问题。