### PR TITLE
fix: 深度重构与API合规性修复

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,21 +7,21 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 env:
-  PLUGIN_NAME: obsidian-mowen-plugin # Change this to match the id of your plugin.
+  PLUGIN_NAME: obsidian-mowen-plugin
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "14.x"
+          node-version: "18.x"
 
       - name: Build
         id: build
@@ -32,60 +32,14 @@ jobs:
           cp main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
           zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
           ls
-          echo "::set-output name=tag_name::$(git tag --sort version:refname | tail -n 1)"
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{ env.PLUGIN_NAME }}.zip
+            main.js
+            manifest.json
+            styles.css
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ github.ref }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload zip file
-        id: upload-zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ env.PLUGIN_NAME }}.zip
-          asset_name: ${{ env.PLUGIN_NAME }}-${{ steps.build.outputs.tag_name }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload main.js
-        id: upload-main
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./main.js
-          asset_name: main.js
-          asset_content_type: text/javascript
-
-      - name: Upload manifest.json
-        id: upload-manifest
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./manifest.json
-          asset_name: manifest.json
-          asset_content_type: application/json
-
-      - name: Upload styles.css
-        id: upload-css
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./styles.css
-          asset_name: styles.css
-          asset_content_type: text/css

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "publish-note-to-mowen",
 	"name": "Publish Note to Mowen Note",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"minAppVersion": "0.15.0",
 	"description": "Publish note to Mowen note mini program.",
 	"author": "ziyou",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
 	"name": "obsidian-mowen-plugin",
-	"version": "1.0.0",
+	"version": "0.0.26",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-mowen-plugin",
-			"version": "1.0.0",
+			"version": "0.0.26",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
-				"esbuild": "0.17.3",
-				"obsidian": "latest",
-				"tslib": "2.4.0",
-				"typescript": "4.7.4"
+				"esbuild": "0.20.2",
+				"obsidian": "1.5.7-1",
+				"tslib": "2.6.2",
+				"typescript": "5.4.2"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -42,14 +42,32 @@
 				"w3c-keyname": "^2.2.4"
 			}
 		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+			"integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
-			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+			"integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -59,13 +77,14 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
-			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+			"integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -75,13 +94,14 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
-			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+			"integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -91,13 +111,14 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
-			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+			"integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -107,13 +128,14 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
-			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+			"integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -123,13 +145,14 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
-			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+			"integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -139,13 +162,14 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
-			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+			"integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -155,13 +179,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
-			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+			"integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -171,13 +196,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
-			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+			"integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -187,13 +213,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
-			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+			"integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -203,13 +230,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
-			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+			"integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
 			"cpu": [
 				"loong64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -219,13 +247,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
-			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+			"integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
 			"cpu": [
 				"mips64el"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -235,13 +264,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
-			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+			"integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -251,13 +281,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
-			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+			"integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -267,13 +298,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
-			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+			"integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -283,13 +315,14 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
-			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+			"integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -299,13 +332,14 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
-			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+			"integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -315,13 +349,14 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
-			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+			"integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -331,13 +366,14 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
-			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+			"integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"sunos"
@@ -347,13 +383,14 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
-			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+			"integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -363,13 +400,14 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
-			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+			"integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -379,13 +417,14 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
-			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+			"integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1014,11 +1053,12 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
-			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+			"integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -1026,28 +1066,29 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.3",
-				"@esbuild/android-arm64": "0.17.3",
-				"@esbuild/android-x64": "0.17.3",
-				"@esbuild/darwin-arm64": "0.17.3",
-				"@esbuild/darwin-x64": "0.17.3",
-				"@esbuild/freebsd-arm64": "0.17.3",
-				"@esbuild/freebsd-x64": "0.17.3",
-				"@esbuild/linux-arm": "0.17.3",
-				"@esbuild/linux-arm64": "0.17.3",
-				"@esbuild/linux-ia32": "0.17.3",
-				"@esbuild/linux-loong64": "0.17.3",
-				"@esbuild/linux-mips64el": "0.17.3",
-				"@esbuild/linux-ppc64": "0.17.3",
-				"@esbuild/linux-riscv64": "0.17.3",
-				"@esbuild/linux-s390x": "0.17.3",
-				"@esbuild/linux-x64": "0.17.3",
-				"@esbuild/netbsd-x64": "0.17.3",
-				"@esbuild/openbsd-x64": "0.17.3",
-				"@esbuild/sunos-x64": "0.17.3",
-				"@esbuild/win32-arm64": "0.17.3",
-				"@esbuild/win32-ia32": "0.17.3",
-				"@esbuild/win32-x64": "0.17.3"
+				"@esbuild/aix-ppc64": "0.20.2",
+				"@esbuild/android-arm": "0.20.2",
+				"@esbuild/android-arm64": "0.20.2",
+				"@esbuild/android-x64": "0.20.2",
+				"@esbuild/darwin-arm64": "0.20.2",
+				"@esbuild/darwin-x64": "0.20.2",
+				"@esbuild/freebsd-arm64": "0.20.2",
+				"@esbuild/freebsd-x64": "0.20.2",
+				"@esbuild/linux-arm": "0.20.2",
+				"@esbuild/linux-arm64": "0.20.2",
+				"@esbuild/linux-ia32": "0.20.2",
+				"@esbuild/linux-loong64": "0.20.2",
+				"@esbuild/linux-mips64el": "0.20.2",
+				"@esbuild/linux-ppc64": "0.20.2",
+				"@esbuild/linux-riscv64": "0.20.2",
+				"@esbuild/linux-s390x": "0.20.2",
+				"@esbuild/linux-x64": "0.20.2",
+				"@esbuild/netbsd-x64": "0.20.2",
+				"@esbuild/openbsd-x64": "0.20.2",
+				"@esbuild/sunos-x64": "0.20.2",
+				"@esbuild/win32-arm64": "0.20.2",
+				"@esbuild/win32-ia32": "0.20.2",
+				"@esbuild/win32-x64": "0.20.2"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -1744,10 +1785,11 @@
 			"peer": true
 		},
 		"node_modules/obsidian": {
-			"version": "1.8.7",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
-			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
+			"version": "1.5.7-1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
+			"integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
@@ -2103,10 +2145,11 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-			"dev": true
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -2156,16 +2199,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+			"integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uri-js": {
@@ -2256,157 +2300,164 @@
 				"w3c-keyname": "^2.2.4"
 			}
 		},
+		"@esbuild/aix-ppc64": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+			"integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+			"dev": true,
+			"optional": true
+		},
 		"@esbuild/android-arm": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
-			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+			"integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
-			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+			"integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
-			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+			"integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
-			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+			"integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
-			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+			"integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
-			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+			"integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
-			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+			"integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
-			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+			"integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
-			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+			"integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ia32": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
-			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+			"integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
-			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+			"integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-mips64el": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
-			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+			"integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ppc64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
-			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+			"integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-riscv64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
-			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+			"integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-s390x": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
-			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+			"integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
-			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+			"integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/netbsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
-			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+			"integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/openbsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
-			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+			"integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/sunos-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
-			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+			"integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
-			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+			"integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-ia32": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
-			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+			"integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
-			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+			"integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -2837,33 +2888,34 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
-			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+			"integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
 			"dev": true,
 			"requires": {
-				"@esbuild/android-arm": "0.17.3",
-				"@esbuild/android-arm64": "0.17.3",
-				"@esbuild/android-x64": "0.17.3",
-				"@esbuild/darwin-arm64": "0.17.3",
-				"@esbuild/darwin-x64": "0.17.3",
-				"@esbuild/freebsd-arm64": "0.17.3",
-				"@esbuild/freebsd-x64": "0.17.3",
-				"@esbuild/linux-arm": "0.17.3",
-				"@esbuild/linux-arm64": "0.17.3",
-				"@esbuild/linux-ia32": "0.17.3",
-				"@esbuild/linux-loong64": "0.17.3",
-				"@esbuild/linux-mips64el": "0.17.3",
-				"@esbuild/linux-ppc64": "0.17.3",
-				"@esbuild/linux-riscv64": "0.17.3",
-				"@esbuild/linux-s390x": "0.17.3",
-				"@esbuild/linux-x64": "0.17.3",
-				"@esbuild/netbsd-x64": "0.17.3",
-				"@esbuild/openbsd-x64": "0.17.3",
-				"@esbuild/sunos-x64": "0.17.3",
-				"@esbuild/win32-arm64": "0.17.3",
-				"@esbuild/win32-ia32": "0.17.3",
-				"@esbuild/win32-x64": "0.17.3"
+				"@esbuild/aix-ppc64": "0.20.2",
+				"@esbuild/android-arm": "0.20.2",
+				"@esbuild/android-arm64": "0.20.2",
+				"@esbuild/android-x64": "0.20.2",
+				"@esbuild/darwin-arm64": "0.20.2",
+				"@esbuild/darwin-x64": "0.20.2",
+				"@esbuild/freebsd-arm64": "0.20.2",
+				"@esbuild/freebsd-x64": "0.20.2",
+				"@esbuild/linux-arm": "0.20.2",
+				"@esbuild/linux-arm64": "0.20.2",
+				"@esbuild/linux-ia32": "0.20.2",
+				"@esbuild/linux-loong64": "0.20.2",
+				"@esbuild/linux-mips64el": "0.20.2",
+				"@esbuild/linux-ppc64": "0.20.2",
+				"@esbuild/linux-riscv64": "0.20.2",
+				"@esbuild/linux-s390x": "0.20.2",
+				"@esbuild/linux-x64": "0.20.2",
+				"@esbuild/netbsd-x64": "0.20.2",
+				"@esbuild/openbsd-x64": "0.20.2",
+				"@esbuild/sunos-x64": "0.20.2",
+				"@esbuild/win32-arm64": "0.20.2",
+				"@esbuild/win32-ia32": "0.20.2",
+				"@esbuild/win32-x64": "0.20.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -3405,9 +3457,9 @@
 			"peer": true
 		},
 		"obsidian": {
-			"version": "1.8.7",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
-			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
+			"version": "1.5.7-1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
+			"integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
 			"dev": true,
 			"requires": {
 				"@types/codemirror": "5.60.8",
@@ -3640,9 +3692,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
 		},
 		"tsutils": {
@@ -3680,9 +3732,9 @@
 			"peer": true
 		},
 		"typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+			"integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
 			"dev": true
 		},
 		"uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
 	"name": "obsidian-mowen-plugin",
-	"version": "1.0.0",
+	"version": "0.0.26",
 	"description": "This is a mowen plugin for Obsidian (https://obsidian.md)",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
-		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production && cp main.js ./dist && cp manifest.json ./dist && cp styles.css ./dist",
+		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production && mkdir -p dist && cp main.js manifest.json styles.css ./dist/",
+		"lint": "eslint src/",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],
@@ -16,10 +17,10 @@
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
-		"esbuild": "0.17.3",
-		"obsidian": "latest",
-		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"esbuild": "0.20.2",
+		"obsidian": "1.5.7-1",
+		"tslib": "2.6.2",
+		"typescript": "5.4.2"
 	},
 	"dependencies": {
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-mowen-plugin",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"description": "This is a mowen plugin for Obsidian (https://obsidian.md)",
 	"main": "main.js",
 	"scripts": {

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,3 +1,11 @@
+/**
+ * AI 智能助手模块
+ * 
+ * 修复项：
+ * - #11: AI 健康检查改为轻量级验证
+ * - #17: 超时泄漏修复（使用 AbortController）
+ */
+
 import { requestUrl, Notice } from 'obsidian';
 import { MowenPluginSettings } from './settings';
 import { 
@@ -56,10 +64,11 @@ interface LLMProvider {
 /**
  * 默认 AI 请求超时时间（毫秒）
  */
-const AI_DEFAULT_TIMEOUT = 60000; // AI 生成通常需要较长时间
+const AI_DEFAULT_TIMEOUT = 60000;
 
 /**
  * DeepSeek 服务商实现
+ * 修复 #17: 使用 AbortController 替代 setTimeout 实现超时
  */
 class DeepSeekProvider implements LLMProvider {
   name = 'deepseek';
@@ -73,7 +82,6 @@ class DeepSeekProvider implements LLMProvider {
   ): Promise<AIGeneratedContent> {
     const url = 'https://api.deepseek.com/chat/completions';
     
-    // 构建系统提示
     const summaryInstruction = generateSummary
       ? "3. 生成一段不超过200字的中文内容摘要。"
       : "";
@@ -103,33 +111,37 @@ ${summaryInstruction}
     };
 
     try {
-      // Obsidian requestUrl 不支持 timeout 参数，使用 Promise.race 实现超时
-      const responsePromise = requestUrl({
-        url,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify(requestBody),
-      });
+      // 修复 #17: 使用 AbortController + clearTimeout 替代 Promise.race 泄漏
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), AI_DEFAULT_TIMEOUT);
       
-      // 超时处理
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
-          reject(new AIServiceError(
+      let response;
+      try {
+        response = await requestUrl({
+          url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify(requestBody),
+        });
+      } catch (error: any) {
+        // 检查是否为超时
+        if (error.name === 'AbortError' || controller.signal.aborted) {
+          throw new AIServiceError(
             MowenErrorCode.NETWORK_TIMEOUT,
             `AI 请求超时(${AI_DEFAULT_TIMEOUT}ms)`,
             this.name
-          ));
-        }, AI_DEFAULT_TIMEOUT);
-      });
-      
-      const response = await Promise.race([responsePromise, timeoutPromise]);
+          );
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeoutId);
+      }
       
       const data = response.json;
       
-      // 检查响应格式
       if (!data.choices || !Array.isArray(data.choices) || data.choices.length === 0) {
         throw new AIServiceError(
           MowenErrorCode.API_INVALID_RESPONSE,
@@ -147,11 +159,9 @@ ${summaryInstruction}
         );
       }
       
-      // 安全解析 JSON
       try {
         const parsedResult: AIGeneratedContent = JSON.parse(resultText);
         
-        // 验证返回字段
         if (!parsedResult.title || typeof parsedResult.title !== 'string') {
           throw new AIServiceError(
             MowenErrorCode.API_INVALID_RESPONSE,
@@ -170,7 +180,7 @@ ${summaryInstruction}
         
         return parsedResult;
         
-      } catch (parseError) {
+      } catch (parseError: any) {
         throw new AIServiceError(
           MowenErrorCode.API_INVALID_RESPONSE,
           `JSON 解析失败: ${parseError.message}`,
@@ -180,12 +190,9 @@ ${summaryInstruction}
       }
       
     } catch (error: any) {
-      // 处理 requestUrl 抛出的错误
       const err = error as any;
       
-      // HTTP 错误
       if (err.status) {
-        // DeepSeek 特殊错误处理
         if (err.status === 401) {
           throw new AIServiceError(
             MowenErrorCode.API_UNAUTHORIZED,
@@ -211,7 +218,6 @@ ${summaryInstruction}
         );
       }
       
-      // 网络错误
       throw new AIServiceError(
         classifyNetworkError(error as Error).code,
         'DeepSeek API 网络请求失败',
@@ -223,26 +229,12 @@ ${summaryInstruction}
 }
 
 /**
- * Kimi 服务商实现（预留扩展）
- */
-// class KimiProvider implements LLMProvider {
-//   name = 'kimi';
-//   async generate(...) { ... }
-// }
-
-/**
  * 服务商工厂函数
  */
 function getProvider(providerName: string): LLMProvider {
   switch (providerName) {
     case 'deepseek':
       return new DeepSeekProvider();
-    
-    // 扩展其他服务商
-    // case 'kimi':
-    //   return new KimiProvider();
-    // case 'openai':
-    //   return new OpenAIProvider();
     
     default:
       throw new AIServiceError(
@@ -264,12 +256,6 @@ export interface AIGenerateOptions {
 
 /**
  * 生成笔记元数据（标题、标签、摘要）
- * 
- * 改进：
- * 1. 添加超时设置
- * 2. 完善的错误处理和分类
- * 3. 可选重试机制
- * 4. JSON 解析安全处理
  */
 export async function generateNoteMetadata(
   settings: MowenPluginSettings, 
@@ -279,35 +265,24 @@ export async function generateNoteMetadata(
   const { provider, apiKey, model, generateSummary, tagsCount } = settings.llmSettings || {};
   const enableRetry = options?.enableRetry ?? true;
 
-  // 配置验证
   if (!provider) {
-    const error = new AIServiceError(
-      MowenErrorCode.CONFIG_INVALID,
-      '未配置 AI 服务商'
-    );
+    const error = new AIServiceError(MowenErrorCode.CONFIG_INVALID, '未配置 AI 服务商');
     error.showNotice();
     return null;
   }
   
   if (!apiKey || apiKey.trim() === '') {
-    const error = new AIServiceError(
-      MowenErrorCode.CONFIG_API_KEY_MISSING,
-      '未配置 AI API Key'
-    );
+    const error = new AIServiceError(MowenErrorCode.CONFIG_API_KEY_MISSING, '未配置 AI API Key');
     error.showNotice();
     return null;
   }
   
   if (!model) {
-    const error = new AIServiceError(
-      MowenErrorCode.CONFIG_INVALID,
-      '未配置 AI 模型'
-    );
+    const error = new AIServiceError(MowenErrorCode.CONFIG_INVALID, '未配置 AI 模型');
     error.showNotice();
     return null;
   }
   
-  // 内容验证
   if (!content || content.trim().length < 50) {
     new Notice('内容过短，无法生成有效的标题和标签');
     return null;
@@ -316,22 +291,16 @@ export async function generateNoteMetadata(
   try {
     const llmProvider = getProvider(provider);
     
-    // 带重试的生成
     const generateOperation = () => llmProvider.generate(
-      apiKey, 
-      model, 
-      content, 
-      generateSummary ?? false, 
-      tagsCount ?? 3
+      apiKey, model, content, generateSummary ?? false, tagsCount ?? 3
     );
     
     const result = enableRetry 
       ? await withRetry(generateOperation, {
           ...DEFAULT_RETRY_CONFIG,
-          // AI 生成重试间隔更长
           initialDelayMs: 2000,
           maxDelayMs: 15000,
-          maxRetries: options?.maxRetries ?? 2 // AI 生成只重试2次
+          maxRetries: options?.maxRetries ?? 2
         }, (attempt, err) => {
           console.log(`[Mowen AI] 第 ${attempt} 次重试，原因: ${err.getUserMessage().title}`);
           new Notice(`AI 生成失败，正在重试(${attempt})...`, 3000);
@@ -341,7 +310,6 @@ export async function generateNoteMetadata(
     return result;
     
   } catch (error: any) {
-    // 统一错误处理
     const aiError = error instanceof AIServiceError 
       ? error 
       : new AIServiceError(
@@ -363,7 +331,8 @@ export async function generateNoteMetadata(
 }
 
 /**
- * 检查 AI 服务是否可用（健康检查）
+ * 修复 #11: AI 服务健康检查
+ * 改为只验证配置完整性 + 轻量级模型列表请求，不消耗生成额度
  */
 export async function checkAIServiceHealth(
   settings: MowenPluginSettings
@@ -373,38 +342,46 @@ export async function checkAIServiceHealth(
   if (!provider || !apiKey || !model) {
     return { 
       valid: false, 
-      error: new AIServiceError(
-        MowenErrorCode.CONFIG_INVALID,
-        'AI 服务配置不完整'
-      ) 
+      error: new AIServiceError(MowenErrorCode.CONFIG_INVALID, 'AI 服务配置不完整') 
     };
   }
   
   try {
-    const llmProvider = getProvider(provider);
+    // 使用轻量级的模型列表 API 检查，不消耗生成额度
+    const response = await requestUrl({
+      url: 'https://api.deepseek.com/models',
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+      },
+    });
     
-    // 发送一个简单的测试请求
-    const testResult = await llmProvider.generate(
-      apiKey,
-      model,
-      '测试内容',
-      false,
-      1
-    );
+    if (response.status === 200) {
+      return { valid: true };
+    }
     
-    return { valid: true };
-    
+    return { 
+      valid: false, 
+      error: new AIServiceError(
+        MowenErrorCode.API_UNAUTHORIZED,
+        'API Key 验证失败',
+        provider
+      )
+    };
   } catch (error: any) {
+    const err = error as any;
+    if (err.status === 401) {
+      return { 
+        valid: false, 
+        error: new AIServiceError(MowenErrorCode.API_UNAUTHORIZED, 'API Key 无效', provider, error)
+      };
+    }
+    
     return { 
       valid: false, 
       error: error instanceof AIServiceError 
         ? error 
-        : new AIServiceError(
-            MowenErrorCode.UNKNOWN,
-            '健康检查失败',
-            provider,
-            error
-          )
+        : new AIServiceError(MowenErrorCode.UNKNOWN, '健康检查失败', provider, error)
     };
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,7 @@ import {
  * NoteAtom 文本标记类型
  * 支持多种 mark 类型组合
  */
-export type MarkType = 'bold' | 'link' | 'highlight' | 'italic' | 'strike';
+export type MarkType = 'bold' | 'link' | 'highlight'; // 墨问 NoteAtom 只支持 bold/highlight/link 三种 marks
 
 /**
  * NoteAtom 文本标记接口
@@ -72,28 +72,35 @@ export interface UploadAuthResponse {
 
 /**
  * 文件上传响应接口
+ * 实际 API 返回字段：uid, fileId, name, path, type, format, extra, size, mime, hash, url, scale, risky
  */
 export interface FileUploadResponse {
   success: boolean;
   data?: {
     file: {
-      fileId: string;
+      uid?: string;
+      fileId: string;  // 实际 API 返回的文件ID字段名为 fileId
+      name?: string;
+      path?: string;
+      type?: number;
+      format?: string;
+      size?: string;
+      mime?: string;
+      url?: string;
     };
   } | null;
   message?: string;
-  error?: MowenError; // 结构化错误对象
+  error?: MowenError;
 }
 
 export interface PublishNoteParams {
   noteId?: string | null;
   apiKey: string;
-  title: string;
-  content: string;
   tags?: string[];
   autoPublish?: boolean;
   settings?: PublishSettings;
   body: NoteAtomNode[];
-  enableRetry?: boolean; // 新增：是否启用重试
+  enableRetry?: boolean;
 }
 
 export interface PublishNoteResult {
@@ -152,19 +159,16 @@ async function safeRequest(
 
 /**
  * 发布/更新笔记到墨问
- * 
- * 改进：
- * 1. 添加重试机制（可选）
- * 2. 完善的 HTTP 状态码处理
- * 3. 二次 API 调用（设置隐私）的错误处理
- * 4. 结构化错误返回
+ *
+ * 修复：按官方文档区分创建和编辑的请求体结构
+ * - 创建 POST /note/create: { body, settings: { autoPublish, tags } }
+ * - 编辑 POST /note/edit:   { noteId, body }
+ * - 隐私设置走独立的 POST /note/set 接口
  */
 export async function publishNoteToMowen(params: PublishNoteParams): Promise<PublishNoteResult> {
   const { 
     noteId, 
     apiKey, 
-    title, 
-    content, 
     tags, 
     autoPublish, 
     settings, 
@@ -182,21 +186,33 @@ export async function publishNoteToMowen(params: PublishNoteParams): Promise<Pub
     };
   }
   
-  // 确定 API 路径
-  const url = noteId 
+  const isEdit = !!noteId;
+  const url = isEdit 
     ? `${baseUrl}/note/edit` 
     : `${baseUrl}/note/create`;
   
-  // 构建请求体
-  const requestBody = JSON.stringify({
-    noteId,
-    body: {
-      type: "doc",
-      content: body,
-    },
-    settings
-  });
-  
+  // 按官方文档构建不同的请求体
+  const requestBody = isEdit
+    ? JSON.stringify({
+        // 编辑接口：只需要 noteId + body
+        noteId,
+        body: {
+          type: "doc",
+          content: body,
+        },
+      })
+    : JSON.stringify({
+        // 创建接口：body + settings（只有 autoPublish 和 tags）
+        body: {
+          type: "doc",
+          content: body,
+        },
+        settings: {
+          autoPublish: autoPublish ?? false,
+          tags: tags ?? [],
+        }
+      });
+
   // 主请求操作
   const mainOperation = async () => {
     const response = await safeRequest(
@@ -235,15 +251,15 @@ export async function publishNoteToMowen(params: PublishNoteParams): Promise<Pub
         })
       : await mainOperation();
     
-    // === 二次 API 调用：设置隐私 ===
-    // 只有需要设置隐私时才执行
-    if (settings && settings.section === 1 && settings.privacy) {
+    // === 二次 API 调用：设置隐私（独立接口） ===
+    // 官方文档：隐私设置走 /note/set，不在创建/编辑接口中
+    // 默认创建的笔记是 public，只有非 public 时才需要调用 /note/set
+    if (settings && settings.section === 1 && settings.privacy && settings.privacy.type !== 'public') {
       try {
         await updateNotePrivacy(result.noteId, apiKey, settings);
       } catch (privacyError) {
         // 隐私设置失败不应影响整体发布结果，但需记录警告
         console.warn('[Mowen] 隐私设置更新失败:', privacyError);
-        // 显示 Notice 提示用户
         if (privacyError instanceof MowenError) {
           new Notice(`笔记已发布，但隐私设置更新失败: ${privacyError.getUserMessage().title}`, 5000);
         } else {
@@ -280,6 +296,20 @@ async function updateNotePrivacy(
   apiKey: string, 
   settings: PublishSettings
 ): Promise<void> {
+  // 按官方文档构建 /note/set 请求体
+  const privacy = settings.privacy;
+  if (!privacy) return;
+  const privacyPayload: Record<string, unknown> = {
+    type: privacy.type,
+  };
+  if (privacy.rule) {
+    privacyPayload.rule = {
+      noShare: privacy.rule.noShare ?? false,
+      // 官方文档 expireAt 类型为 string（时间戳秒的字符串形式）
+      expireAt: String(privacy.rule.expireAt ?? 0),
+    };
+  }
+
   const response = await safeRequest(
     `${baseUrl}/note/set`,
     "POST",
@@ -289,9 +319,9 @@ async function updateNotePrivacy(
     },
     JSON.stringify({
       noteId,
-      section: settings?.section ?? 1,
+      section: 1,
       settings: {
-        privacy: settings?.privacy
+        privacy: privacyPayload
       }
     })
   );
@@ -312,10 +342,11 @@ async function updateNotePrivacy(
 export async function getUploadAuthorization(
   apiKey: string, 
   fileType: number,
-  options?: { timeout?: number; enableRetry?: boolean }
+  options?: { timeout?: number; enableRetry?: boolean; fileName?: string }
 ): Promise<UploadAuthResponse> {
   const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
   const enableRetry = options?.enableRetry ?? true;
+  const fileName = options?.fileName;
   
   // 验证 API Key
   if (!apiKey || apiKey.trim() === '') {
@@ -334,7 +365,7 @@ export async function getUploadAuthorization(
         "Content-Type": "application/json",
         "Authorization": `Bearer ${apiKey}`,
       },
-      JSON.stringify({ fileType }),
+      JSON.stringify({ fileType, ...(fileName ? { fileName } : {}) }),
       timeout
     );
     
@@ -398,6 +429,8 @@ export async function deliverFile(
     for (const key in authInfo) {
       formData.append(key, authInfo[key]);
     }
+    // 修复 #15: 文件投递必须带 x:file_name，否则 PDF 等文件名缺失
+    formData.append('x:file_name', fileName);
     formData.append('file', fileBlob, fileName);
     
     // 使用 AbortController 实现超时
@@ -429,7 +462,7 @@ export async function deliverFile(
       
       return { 
         success: true, 
-        data: result.file 
+        data: { file: result.file }
       };
       
     } catch (error: any) {
@@ -484,7 +517,7 @@ export async function batchUploadFiles(
   // 并发上传所有文件
   const uploadPromises = files.map(async (file, i) => {
     // 获取上传授权
-    const authRes = await getUploadAuthorization(apiKey, file.fileType);
+    const authRes = await getUploadAuthorization(apiKey, file.fileType, { fileName: file.name });
     if (!authRes.success || !authRes.data) {
       errorCollector.add(i, authRes.error!, file.name);
       return { success: false, error: authRes.error! };
@@ -501,7 +534,7 @@ export async function batchUploadFiles(
     if (uploadRes.success && uploadRes.data) {
       return { 
         success: true, 
-        fileId: uploadRes.data.file?.fileId 
+        fileId: uploadRes.data.file?.fileId || ''
       };
     } else {
       errorCollector.add(i, uploadRes.error!, file.name);

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,8 +20,8 @@ export type MarkType = 'bold' | 'link' | 'highlight' | 'italic' | 'strike';
  * 用于表示文本的格式化标记（加粗、链接、高亮等）
  */
 export interface NoteAtomMark {
-  type: MarkType | string; // 扩展支持更多类型
-  attrs?: Record<string, any>; // 例如链接的 href 属性
+  type: MarkType; // 移除 | string，严格类型约束
+  attrs?: Record<string, unknown>; // 移除 any，使用 unknown
 }
 
 /**
@@ -33,7 +33,7 @@ export interface NoteAtomNode {
   content?: NoteAtomNode[]; // 嵌套子节点
   text?: string; // 文本内容（仅 text 类型节点）
   marks?: NoteAtomMark[]; // 文本标记
-  attrs?: Record<string, any>; // 属性，如 uuid, align, alt 等
+  attrs?: Record<string, unknown>; // 属性，如 uuid, align, alt 等
 }
 
 /**
@@ -67,7 +67,7 @@ export interface UploadAuthResponse {
     [key: string]: string; // 其他表单字段
   } | null;
   message?: string;
-  error?: MowenError; // 新增：结构化错误对象
+  error?: MowenError; // 结构化错误对象
 }
 
 /**
@@ -81,7 +81,7 @@ export interface FileUploadResponse {
     };
   } | null;
   message?: string;
-  error?: MowenError; // 新增：结构化错误对象
+  error?: MowenError; // 结构化错误对象
 }
 
 export interface PublishNoteParams {
@@ -99,8 +99,8 @@ export interface PublishNoteParams {
 export interface PublishNoteResult {
   success: boolean;
   message: string;
-  data?: any;
-  error?: MowenError; // 新增：结构化错误对象
+  data?: unknown;
+  error?: MowenError; // 结构化错误对象
 }
 
 /** API 基础地址 */
@@ -472,25 +472,22 @@ export async function deliverFile(
 }
 
 /**
- * 批量文件上传（带错误聚合）
- * 用于处理包含多个图片/文件的笔记
+ * 批量文件上传（带错误聚合，并发上传）
+ * 修复 #16: 使用 Promise.allSettled 并发上传
  */
 export async function batchUploadFiles(
   apiKey: string,
   files: Array<{ blob: Blob; name: string; fileType: number }>
 ): Promise<Array<{ success: boolean; fileId?: string; error?: MowenError }>> {
-  const results: Array<{ success: boolean; fileId?: string; error?: MowenError }> = [];
   const errorCollector = new BatchErrorCollector();
   
-  for (let i = 0; i < files.length; i++) {
-    const file = files[i];
-    
+  // 并发上传所有文件
+  const uploadPromises = files.map(async (file, i) => {
     // 获取上传授权
     const authRes = await getUploadAuthorization(apiKey, file.fileType);
     if (!authRes.success || !authRes.data) {
       errorCollector.add(i, authRes.error!, file.name);
-      results.push({ success: false, error: authRes.error! });
-      continue;
+      return { success: false, error: authRes.error! };
     }
     
     // 执行上传
@@ -502,22 +499,35 @@ export async function batchUploadFiles(
     );
     
     if (uploadRes.success && uploadRes.data) {
-      results.push({ 
+      return { 
         success: true, 
         fileId: uploadRes.data.file?.fileId 
-      });
+      };
     } else {
       errorCollector.add(i, uploadRes.error!, file.name);
-      results.push({ success: false, error: uploadRes.error! });
+      return { success: false, error: uploadRes.error! };
     }
-  }
+  });
+  
+  const results = await Promise.allSettled(uploadPromises);
+  
+  // 处理结果
+  const finalResults = results.map((result, i) => {
+    if (result.status === 'fulfilled') {
+      return result.value;
+    } else {
+      const error = classifyNetworkError(result.reason as Error);
+      errorCollector.add(i, error, files[i].name);
+      return { success: false, error };
+    }
+  });
   
   // 显示汇总提示
   if (errorCollector.hasErrors()) {
     errorCollector.showSummaryNotice();
   }
   
-  return results;
+  return finalResults;
 }
 
 /**
@@ -534,7 +544,7 @@ export function markdownTagsToNoteAtomTags(markdown: string, defaultTag: string 
       
       if (frontmatterObj && typeof frontmatterObj === 'object' && frontmatterObj.tags) {
         if (Array.isArray(frontmatterObj.tags)) {
-          tags = frontmatterObj.tags.map((tag: any) => String(tag).trim()).filter(Boolean);
+          tags = frontmatterObj.tags.map((tag: unknown) => String(tag).trim()).filter(Boolean);
         } else if (typeof frontmatterObj.tags === 'string') {
           tags = frontmatterObj.tags.split(',').map((t: string) => t.trim()).filter(Boolean);
         }

--- a/src/converter/MarkdownConverter.ts
+++ b/src/converter/MarkdownConverter.ts
@@ -1,0 +1,541 @@
+/**
+ * Markdown 转 NoteAtom 转换器
+ * 负责将 Markdown 文本转换为墨问 NoteAtom 结构
+ * 
+ * 修复项：
+ * - #5: 引用块解析 Bug（非引用行不再被误归入引用）
+ * - #8: 代码块使用 code_block 类型
+ * - #9: 支持 ![](url) 标准图片语法
+ * - #10: 支持 *斜体* 格式
+ */
+
+import { App, TFile, getFrontMatterInfo, Notice } from 'obsidian';
+import { NoteAtomMark, NoteAtomNode, getUploadAuthorization, deliverFile, getFileType, getMimeType, getFileTypeName } from '../api';
+import { MowenPluginSettings } from '../settings';
+
+/** 转换上下文，传递依赖 */
+export interface ConverterContext {
+	app: App;
+	settings: MowenPluginSettings;
+}
+
+export class MarkdownConverter {
+	private context: ConverterContext;
+
+	constructor(context: ConverterContext) {
+		this.context = context;
+	}
+
+	/**
+	 * 去除 YAML frontmatter
+	 */
+	stripFrontmatter(content: string): string {
+		if (content.startsWith('---')) {
+			const end = content.indexOf('\n---', 3);
+			if (end !== -1) {
+				return content.slice(end + 4).trimStart();
+			}
+		}
+		return content;
+	}
+
+	/**
+	 * 将 Markdown 文本转换为 NoteAtom 结构
+	 */
+	async convert(title: string, markdown: string, summary: string | null = null): Promise<{ content: NoteAtomNode[] }> {
+		let contentToProcess = markdown;
+		const frontMatterInfo = getFrontMatterInfo(markdown);
+		if (frontMatterInfo.exists) {
+			contentToProcess = markdown.slice(frontMatterInfo.contentStart);
+		}
+
+		const lines = contentToProcess.split('\n');
+		const content: NoteAtomNode[] = [];
+
+		// 标题（加粗）
+		content.push({
+			type: 'paragraph',
+			content: [
+				{ type: 'text', text: title, marks: [{ type: 'bold' }] }
+			]
+		});
+		// 标题后空行
+		content.push({ type: 'paragraph' });
+
+		// 摘要（引用块）
+		if (summary) {
+			content.push({
+				type: 'quote',
+				content: [{ type: 'text', text: summary }]
+			});
+			content.push({ type: 'paragraph' });
+		}
+
+		// === 第一遍：收集所有图片链接，并行上传 ===
+		const imageUploadMap = await this.preUploadImages(lines);
+
+		// === 第二遍：逐行转换 ===
+		let inCode = false;
+		let codeBuffer: string[] = [];
+		let codeLanguage = '';
+
+		for (let i = 0; i < lines.length; i++) {
+			let line = lines[i];
+			const trimmedLine = line.trim();
+
+			// --- 代码块处理 ---
+			if (trimmedLine.startsWith('```')) {
+				if (!inCode) {
+					// 开始代码块
+					inCode = true;
+					codeLanguage = trimmedLine.slice(3).trim();
+					codeBuffer = [];
+					continue;
+				} else {
+					// 结束代码块，输出为 code_block 节点
+					inCode = false;
+					content.push({
+						type: 'code_block',
+						attrs: {
+							language: codeLanguage || 'plaintext',
+						},
+						content: [{ type: 'text', text: codeBuffer.join('\n') }]
+					});
+					content.push({ type: 'paragraph' }); // 代码块后空行
+					codeBuffer = [];
+					codeLanguage = '';
+					continue;
+				}
+			}
+
+			if (inCode) {
+				codeBuffer.push(line); // 保持原始缩进
+				continue;
+			}
+
+			// --- 分隔线处理 ---
+			if (/^(-{3,}|\*{3,}|_{3,})$/.test(trimmedLine)) {
+				content.push({
+					type: 'paragraph',
+					content: [{ type: 'text', text: '———', marks: [{ type: 'bold' }] }]
+				});
+				content.push({ type: 'paragraph' });
+				continue;
+			}
+
+			// --- 引用块处理（修复 #5）---
+			if (trimmedLine.startsWith('>')) {
+				// 收集连续引用行
+				const quoteLines: string[] = [];
+				while (i < lines.length && lines[i].trim().startsWith('>')) {
+					quoteLines.push(lines[i].trim().replace(/^>\s*/, ''));
+					i++;
+				}
+				i--; // 回退一行，外层循环会 i++
+				content.push({
+					type: 'quote',
+					content: [{ type: 'text', text: quoteLines.join('\n') }]
+				});
+				content.push({ type: 'paragraph' });
+				continue;
+			}
+
+			// --- 图片或内嵌笔记 ---
+			const embedWikiMatch = trimmedLine.match(/^!\[\[(.+?)\]\]/);  // ![[image.png]]
+			const embedStdMatch = trimmedLine.match(/^!\[([^\]]*)\]\(([^)]+)\)/);  // ![alt](url) - 修复 #9
+			const internalLinkMatch = trimmedLine.match(/^\[\[(.+?)\]\]/);  // [[note]]
+
+			if (embedWikiMatch || embedStdMatch || internalLinkMatch) {
+				await this.processEmbedOrLink(
+					trimmedLine, embedWikiMatch, embedStdMatch, internalLinkMatch,
+					imageUploadMap, content
+				);
+				continue;
+			}
+
+			// --- 标题 ---
+			const headingMatch = trimmedLine.match(/^(#+)\s*(.+)$/);
+			if (headingMatch) {
+				content.push({
+					type: 'paragraph',
+					content: [
+						{
+							type: 'text',
+							text: headingMatch[2],
+							marks: [{ type: 'bold' }]
+						}
+					]
+				});
+				continue;
+			}
+
+			// --- 有序/无序列表 ---
+			const listMatch = trimmedLine.match(/^(\s*)([-*+]|\d+\.)\s+(.+)$/);
+			if (listMatch) {
+				const listContent = this.processInlineFormatting(listMatch[3]);
+				content.push({
+					type: 'paragraph',
+					content: [
+						{ type: 'text', text: listMatch[2] + ' ' },
+						...listContent
+					]
+				});
+				content.push({ type: 'paragraph' });
+				continue;
+			}
+
+			// --- 普通文本 ---
+			if (trimmedLine !== '') {
+				const parts = this.processInlineFormatting(trimmedLine);
+				if (parts.length > 0) {
+					content.push({
+						type: 'paragraph',
+						content: parts
+					});
+					content.push({ type: 'paragraph' });
+				}
+			}
+		}
+
+		return { content };
+	}
+
+	/**
+	 * 预上传所有图片（并行），返回映射：行索引 -> 上传结果
+	 * 修复 #15：图片并行上传
+	 */
+	private async preUploadImages(lines: string[]): Promise<Map<number, { success: boolean; uuid?: string; fileType?: number; alt?: string; originalLine: string }>> {
+		const uploadMap = new Map<number, { success: boolean; uuid?: string; fileType?: number; alt?: string; originalLine: string }>();
+
+		// 收集需要上传的图片行
+		const imageTasks: Array<{ lineIndex: number; linkText: string; altText: string }> = [];
+
+		for (let i = 0; i < lines.length; i++) {
+			const trimmedLine = lines[i].trim();
+			// Wiki 链接图片: ![[image.png]]
+			const wikiMatch = trimmedLine.match(/^!\[\[(.+?)\]\]/);
+			if (wikiMatch) {
+				imageTasks.push({ lineIndex: i, linkText: wikiMatch[1], altText: wikiMatch[1] });
+				continue;
+			}
+			// 标准图片: ![alt](url) - 仅处理本地路径，不处理 http 链接
+			const stdMatch = trimmedLine.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
+			if (stdMatch && !stdMatch[2].startsWith('http')) {
+				imageTasks.push({ lineIndex: i, linkText: stdMatch[2], altText: stdMatch[1] || stdMatch[2] });
+			}
+		}
+
+		if (imageTasks.length === 0) return uploadMap;
+
+		// 并行上传
+		const uploadPromises = imageTasks.map(async (task) => {
+			const result = await this.uploadSingleImage(task.linkText, task.altText);
+			uploadMap.set(task.lineIndex, {
+				success: result.success,
+				uuid: result.uuid,
+				fileType: result.fileType,
+				alt: task.altText,
+				originalLine: lines[task.lineIndex].trim()
+			});
+		});
+
+		await Promise.allSettled(uploadPromises);
+		return uploadMap;
+	}
+
+	/**
+	 * 上传单个图片/文件
+	 */
+	private async uploadSingleImage(linkText: string, altText: string): Promise<{ success: boolean; uuid?: string; fileType?: number }> {
+		const { app, settings } = this.context;
+
+		let file: TFile | null = null;
+		const currentActiveFile = app.workspace.getActiveFile();
+		const sourcePath = currentActiveFile ? currentActiveFile.path : '';
+
+		if (linkText) {
+			file = app.metadataCache.getFirstLinkpathDest(linkText, sourcePath);
+		}
+
+		if (!(file instanceof TFile)) {
+			new Notice(`文件未找到: ${linkText}`);
+			return { success: false };
+		}
+
+		// 判断文件类型
+		if (file.extension.toLowerCase() === 'md') {
+			// 内嵌笔记不在此处理
+			return { success: false };
+		}
+
+		try {
+			new Notice(`正在上传图片: ${file.path}`);
+			const mimeType = getMimeType(file.extension);
+			const fileBlob = new Blob([await app.vault.readBinary(file)], { type: mimeType });
+			const fileType = getFileType(file.extension);
+			const fileTypeName = getFileTypeName(fileType);
+			const fName = file.name;
+
+			const authRes = await getUploadAuthorization(settings.apiKey, fileType);
+			if (authRes.success && authRes.data && authRes.data.endpoint) {
+				const uploadRes = await deliverFile(authRes.data.endpoint, authRes.data as Record<string, string>, fileBlob, fName);
+				if (uploadRes.success && uploadRes.data) {
+					const uuidKey = fileType === 2 ? 'audio-uuid' : 'uuid';
+					const uuid = uploadRes.data.file?.fileId || '';
+					new Notice(`图片上传成功: ${fName}`);
+					return { success: true, uuid, fileType };
+				} else {
+					new Notice(`图片上传失败: ${fName} - ${uploadRes.message}`);
+				}
+			} else {
+				new Notice(`获取图片上传授权失败: ${authRes.message}`);
+			}
+		} catch (error) {
+			console.error('图片上传异常:', error);
+			new Notice(`图片上传异常: ${altText}`);
+		}
+
+		return { success: false };
+	}
+
+	/**
+	 * 处理图片/内嵌链接
+	 */
+	private async processEmbedOrLink(
+		line: string,
+		embedWikiMatch: RegExpMatchArray | null,
+		embedStdMatch: RegExpMatchArray | null,
+		internalLinkMatch: RegExpMatchArray | null,
+		imageUploadMap: Map<number, { success: boolean; uuid?: string; fileType?: number; alt?: string; originalLine: string }>,
+		content: NoteAtomNode[]
+	): Promise<void> {
+		const { app, settings } = this.context;
+		let linkText = '';
+		let altText = '';
+		let isImage = false;
+
+		if (embedWikiMatch) {
+			linkText = embedWikiMatch[1];
+			altText = linkText;
+			isImage = true;
+		} else if (embedStdMatch) {
+			linkText = embedStdMatch[2];
+			altText = embedStdMatch[1] || linkText;
+			isImage = true;
+		} else if (internalLinkMatch) {
+			linkText = internalLinkMatch[1];
+		}
+
+		// 尝试解析为文件
+		let file: TFile | null = null;
+		const currentActiveFile = app.workspace.getActiveFile();
+		const sourcePath = currentActiveFile ? currentActiveFile.path : '';
+
+		if (linkText) {
+			file = app.metadataCache.getFirstLinkpathDest(linkText, sourcePath);
+		}
+
+		if (file instanceof TFile) {
+			if (file.extension.toLowerCase() === 'md') {
+				// 内嵌 Markdown 笔记
+				new Notice(`正在处理内嵌笔记: ${file.path}`);
+				const noteId = this.getNoteIdFromFileCache(file);
+				if (noteId) {
+					content.push({
+						type: 'note',
+						attrs: { uuid: noteId }
+					});
+					new Notice(`成功嵌入笔记: ${file.name}`);
+				} else {
+					new Notice(`内嵌笔记 ${file.name} 未找到 noteId，将作为普通文本插入`);
+					content.push({
+						type: 'paragraph',
+						content: [{ type: 'text', text: `[[${linkText}]]` }]
+					});
+				}
+			} else if (isImage) {
+				// 图片文件 - 使用预上传结果
+				// 由于预上传是按行索引映射的，这里需要根据 linkText 查找
+				// 直接再次上传（已在 preUploadImages 中缓存结果）
+				const uploadResult = await this.uploadSingleImage(linkText, altText);
+				if (uploadResult.success && uploadResult.uuid) {
+					const fileType = uploadResult.fileType || 1;
+					const fileTypeName = getFileTypeName(fileType);
+					const uuidKey = fileType === 2 ? 'audio-uuid' : 'uuid';
+					content.push({
+						type: fileTypeName,
+						attrs: {
+							[uuidKey]: uploadResult.uuid,
+							align: 'center',
+							alt: altText
+						}
+					});
+				} else {
+					// 上传失败 fallback
+					content.push({
+						type: 'paragraph',
+						content: [{ type: 'text', text: `![${altText}](${linkText})` }]
+					});
+				}
+			}
+		} else if (isImage && linkText.startsWith('http')) {
+			// 外部 URL 图片 - 直接作为链接保留
+			content.push({
+				type: 'paragraph',
+				content: [{ type: 'text', text: `![${altText}](${linkText})` }]
+			});
+		} else {
+			new Notice(`文件未找到: ${linkText}`);
+			content.push({
+				type: 'paragraph',
+				content: [{ type: 'text', text: isImage ? `![${altText}](${linkText})` : `[[${linkText}]]` }]
+			});
+		}
+	}
+
+	/**
+	 * 获取文件的 noteId（从缓存）
+	 */
+	private getNoteIdFromFileCache(file: TFile): string | null {
+		const fileCache = this.context.app.metadataCache.getFileCache(file);
+		const frontmatterObj: Record<string, unknown> = fileCache?.frontmatter || {};
+		const customKey = this.context.settings.noteIdKey || 'noteId';
+		const defaultKey = 'noteId';
+
+		const keysToCheck: string[] = [customKey];
+		if (this.context.settings.enableLegacyNoteIdFallback && customKey !== defaultKey) {
+			keysToCheck.push(defaultKey);
+		}
+
+		for (const key of keysToCheck) {
+			const value = frontmatterObj[key];
+			if (value) {
+				return String(value);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * 处理行内格式化（加粗、高亮、斜体、链接的组合）
+	 * 修复 #10：支持 *斜体* 格式
+	 */
+	processInlineFormatting(line: string): NoteAtomNode[] {
+		const parts: NoteAtomNode[] = [];
+		const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+		let lastIndex = 0;
+		let match;
+
+		// 跟踪当前的 bold/highlight/italic 状态
+		let currentFormatMarks: NoteAtomMark[] = [];
+
+		while ((match = linkRegex.exec(line)) !== null) {
+			// 处理链接前的文本
+			if (match.index > lastIndex) {
+				const textBeforeLink = line.slice(lastIndex, match.index);
+				currentFormatMarks = this.processTextSegment(textBeforeLink, parts, []);
+			}
+
+			// 处理链接
+			const linkMark: NoteAtomMark = { type: 'link', attrs: { href: match[2] } };
+			const combinedMarks = [...currentFormatMarks, linkMark];
+			this.processTextSegment(match[1], parts, combinedMarks);
+
+			lastIndex = match.index + match[0].length;
+		}
+
+		// 处理链接后的剩余文本
+		if (lastIndex < line.length) {
+			const remainingText = line.slice(lastIndex);
+			this.processTextSegment(remainingText, parts, currentFormatMarks);
+		}
+
+		return parts;
+	}
+
+	/**
+	 * 处理文本片段的格式标记，支持 marks 叠加
+	 * 支持：**加粗**、==高亮==、*斜体*
+	 */
+	processTextSegment(textSegment: string, partsArray: NoteAtomNode[], baseMarks: NoteAtomMark[] = []): NoteAtomMark[] {
+		let currentText = '';
+		let activeMarks: NoteAtomMark[] = [...baseMarks];
+
+		let i = 0;
+		while (i < textSegment.length) {
+			// 检测 highlight 标记 (==text==)
+			if (textSegment[i] === '=' && textSegment[i + 1] === '=') {
+				if (currentText) {
+					partsArray.push({
+						type: 'text',
+						text: currentText,
+						marks: activeMarks.length > 0 ? [...activeMarks] : [...baseMarks]
+					});
+					currentText = '';
+				}
+				this.toggleMark(activeMarks, 'highlight');
+				i += 2;
+				continue;
+			}
+
+			// 检测 bold 标记 (**) - 必须在斜体之前检查
+			if (textSegment[i] === '*' && textSegment[i + 1] === '*') {
+				if (currentText) {
+					partsArray.push({
+						type: 'text',
+						text: currentText,
+						marks: activeMarks.length > 0 ? [...activeMarks] : [...baseMarks]
+					});
+					currentText = '';
+				}
+				this.toggleMark(activeMarks, 'bold');
+				i += 2;
+				continue;
+			}
+
+			// 检测 italic 标记 (*text*) - 修复 #10
+			if (textSegment[i] === '*' && textSegment[i + 1] !== '*' && (i === 0 || textSegment[i - 1] !== '*')) {
+				// 确保不是 ** 的后半部分
+				if (currentText) {
+					partsArray.push({
+						type: 'text',
+						text: currentText,
+						marks: activeMarks.length > 0 ? [...activeMarks] : [...baseMarks]
+					});
+					currentText = '';
+				}
+				this.toggleMark(activeMarks, 'italic');
+				i += 1;
+				continue;
+			}
+
+			currentText += textSegment[i];
+			i++;
+		}
+
+		// 处理末尾剩余文本
+		if (currentText) {
+			partsArray.push({
+				type: 'text',
+				text: currentText,
+				marks: activeMarks.length > 0 ? [...activeMarks] : [...baseMarks]
+			});
+		}
+
+		// 返回结束时的 marks 状态
+		return activeMarks.filter(m => m.type === 'bold' || m.type === 'highlight' || m.type === 'italic');
+	}
+
+	/**
+	 * 切换 mark 状态
+	 */
+	private toggleMark(marks: NoteAtomMark[], markType: 'bold' | 'highlight' | 'italic'): void {
+		const index = marks.findIndex(m => m.type === markType);
+		if (index !== -1) {
+			marks.splice(index, 1);
+		} else {
+			marks.push({ type: markType });
+		}
+	}
+}

--- a/src/converter/MarkdownConverter.ts
+++ b/src/converter/MarkdownConverter.ts
@@ -4,9 +4,9 @@
  * 
  * 修复项：
  * - #5: 引用块解析 Bug（非引用行不再被误归入引用）
- * - #8: 代码块使用 code_block 类型
+ * - #8: 代码块使用 codeblock 类型
  * - #9: 支持 ![](url) 标准图片语法
- * - #10: 支持 *斜体* 格式
+ * - #10: 支持 *斜体* 格式（转为 highlight 因为墨问不支持 italic marks）
  */
 
 import { App, TFile, getFrontMatterInfo, Notice } from 'obsidian';
@@ -71,10 +71,10 @@ export class MarkdownConverter {
 			content.push({ type: 'paragraph' });
 		}
 
-		// === 第一遍：收集所有图片链接，并行上传 ===
-		const imageUploadMap = await this.preUploadImages(lines);
+		// === 图片上传缓存（避免同一图片重复上传） ===
+		const uploadCache = new Map<string, { success: boolean; uuid?: string; fileType?: number; alt?: string }>();
 
-		// === 第二遍：逐行转换 ===
+		// === 逐行转换 ===
 		let inCode = false;
 		let codeBuffer: string[] = [];
 		let codeLanguage = '';
@@ -92,10 +92,10 @@ export class MarkdownConverter {
 					codeBuffer = [];
 					continue;
 				} else {
-					// 结束代码块，输出为 code_block 节点
+					// 结束代码块，输出为 codeblock 节点（墨问 API 类型名为 codeblock）
 					inCode = false;
 					content.push({
-						type: 'code_block',
+						type: 'codeblock',
 						attrs: {
 							language: codeLanguage || 'plaintext',
 						},
@@ -134,7 +134,7 @@ export class MarkdownConverter {
 				i--; // 回退一行，外层循环会 i++
 				content.push({
 					type: 'quote',
-					content: [{ type: 'text', text: quoteLines.join('\n') }]
+					content: this.processInlineFormatting(quoteLines.join('\n'))
 				});
 				content.push({ type: 'paragraph' });
 				continue;
@@ -148,7 +148,7 @@ export class MarkdownConverter {
 			if (embedWikiMatch || embedStdMatch || internalLinkMatch) {
 				await this.processEmbedOrLink(
 					trimmedLine, embedWikiMatch, embedStdMatch, internalLinkMatch,
-					imageUploadMap, content
+					uploadCache, content
 				);
 				continue;
 			}
@@ -201,49 +201,6 @@ export class MarkdownConverter {
 	}
 
 	/**
-	 * 预上传所有图片（并行），返回映射：行索引 -> 上传结果
-	 * 修复 #15：图片并行上传
-	 */
-	private async preUploadImages(lines: string[]): Promise<Map<number, { success: boolean; uuid?: string; fileType?: number; alt?: string; originalLine: string }>> {
-		const uploadMap = new Map<number, { success: boolean; uuid?: string; fileType?: number; alt?: string; originalLine: string }>();
-
-		// 收集需要上传的图片行
-		const imageTasks: Array<{ lineIndex: number; linkText: string; altText: string }> = [];
-
-		for (let i = 0; i < lines.length; i++) {
-			const trimmedLine = lines[i].trim();
-			// Wiki 链接图片: ![[image.png]]
-			const wikiMatch = trimmedLine.match(/^!\[\[(.+?)\]\]/);
-			if (wikiMatch) {
-				imageTasks.push({ lineIndex: i, linkText: wikiMatch[1], altText: wikiMatch[1] });
-				continue;
-			}
-			// 标准图片: ![alt](url) - 仅处理本地路径，不处理 http 链接
-			const stdMatch = trimmedLine.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
-			if (stdMatch && !stdMatch[2].startsWith('http')) {
-				imageTasks.push({ lineIndex: i, linkText: stdMatch[2], altText: stdMatch[1] || stdMatch[2] });
-			}
-		}
-
-		if (imageTasks.length === 0) return uploadMap;
-
-		// 并行上传
-		const uploadPromises = imageTasks.map(async (task) => {
-			const result = await this.uploadSingleImage(task.linkText, task.altText);
-			uploadMap.set(task.lineIndex, {
-				success: result.success,
-				uuid: result.uuid,
-				fileType: result.fileType,
-				alt: task.altText,
-				originalLine: lines[task.lineIndex].trim()
-			});
-		});
-
-		await Promise.allSettled(uploadPromises);
-		return uploadMap;
-	}
-
-	/**
 	 * 上传单个图片/文件
 	 */
 	private async uploadSingleImage(linkText: string, altText: string): Promise<{ success: boolean; uuid?: string; fileType?: number }> {
@@ -276,7 +233,7 @@ export class MarkdownConverter {
 			const fileTypeName = getFileTypeName(fileType);
 			const fName = file.name;
 
-			const authRes = await getUploadAuthorization(settings.apiKey, fileType);
+			const authRes = await getUploadAuthorization(settings.apiKey, fileType, { fileName: fName });
 			if (authRes.success && authRes.data && authRes.data.endpoint) {
 				const uploadRes = await deliverFile(authRes.data.endpoint, authRes.data as Record<string, string>, fileBlob, fName);
 				if (uploadRes.success && uploadRes.data) {
@@ -300,13 +257,14 @@ export class MarkdownConverter {
 
 	/**
 	 * 处理图片/内嵌链接
+	 * 使用 uploadCache 避免同一图片重复上传
 	 */
 	private async processEmbedOrLink(
 		line: string,
 		embedWikiMatch: RegExpMatchArray | null,
 		embedStdMatch: RegExpMatchArray | null,
 		internalLinkMatch: RegExpMatchArray | null,
-		imageUploadMap: Map<number, { success: boolean; uuid?: string; fileType?: number; alt?: string; originalLine: string }>,
+		uploadCache: Map<string, { success: boolean; uuid?: string; fileType?: number; alt?: string }>,
 		content: NoteAtomNode[]
 	): Promise<void> {
 		const { app, settings } = this.context;
@@ -354,28 +312,56 @@ export class MarkdownConverter {
 					});
 				}
 			} else if (isImage) {
-				// 图片文件 - 使用预上传结果
-				// 由于预上传是按行索引映射的，这里需要根据 linkText 查找
-				// 直接再次上传（已在 preUploadImages 中缓存结果）
-				const uploadResult = await this.uploadSingleImage(linkText, altText);
-				if (uploadResult.success && uploadResult.uuid) {
-					const fileType = uploadResult.fileType || 1;
-					const fileTypeName = getFileTypeName(fileType);
-					const uuidKey = fileType === 2 ? 'audio-uuid' : 'uuid';
-					content.push({
-						type: fileTypeName,
-						attrs: {
-							[uuidKey]: uploadResult.uuid,
-							align: 'center',
-							alt: altText
-						}
-					});
+				// 图片文件 - 检查缓存，避免重复上传
+				const cachedResult = uploadCache.get(linkText);
+				if (cachedResult) {
+					// 已缓存（无论成功失败），直接使用
+					if (cachedResult.success && cachedResult.uuid) {
+						const fileType = cachedResult.fileType || 1;
+						const fileTypeName = getFileTypeName(fileType);
+						const uuidKey = fileType === 2 ? 'audio-uuid' : 'uuid';
+						content.push({
+							type: fileTypeName,
+							attrs: {
+								[uuidKey]: cachedResult.uuid,
+								align: 'center',
+								alt: cachedResult.alt || altText
+							}
+						});
+					} else {
+						content.push({
+							type: 'paragraph',
+							content: [{ type: 'text', text: `![${altText}](${linkText})` }]
+						});
+					}
 				} else {
-					// 上传失败 fallback
-					content.push({
-						type: 'paragraph',
-						content: [{ type: 'text', text: `![${altText}](${linkText})` }]
+					// 未缓存，执行上传并缓存结果
+					const uploadResult = await this.uploadSingleImage(linkText, altText);
+					uploadCache.set(linkText, {
+						success: uploadResult.success,
+						uuid: uploadResult.uuid,
+						fileType: uploadResult.fileType,
+						alt: altText,
 					});
+					if (uploadResult.success && uploadResult.uuid) {
+						const fileType = uploadResult.fileType || 1;
+						const fileTypeName = getFileTypeName(fileType);
+						const uuidKey = fileType === 2 ? 'audio-uuid' : 'uuid';
+						content.push({
+							type: fileTypeName,
+							attrs: {
+								[uuidKey]: uploadResult.uuid,
+								align: 'center',
+								alt: altText
+							}
+						});
+					} else {
+						// 上传失败 fallback
+						content.push({
+							type: 'paragraph',
+							content: [{ type: 'text', text: `![${altText}](${linkText})` }]
+						});
+					}
 				}
 			}
 		} else if (isImage && linkText.startsWith('http')) {
@@ -495,6 +481,7 @@ export class MarkdownConverter {
 			}
 
 			// 检测 italic 标记 (*text*) - 修复 #10
+			// 注意：墨问 NoteAtom 不支持 italic marks，转换为 highlight
 			if (textSegment[i] === '*' && textSegment[i + 1] !== '*' && (i === 0 || textSegment[i - 1] !== '*')) {
 				// 确保不是 ** 的后半部分
 				if (currentText) {
@@ -505,7 +492,7 @@ export class MarkdownConverter {
 					});
 					currentText = '';
 				}
-				this.toggleMark(activeMarks, 'italic');
+				this.toggleMark(activeMarks, 'highlight');
 				i += 1;
 				continue;
 			}
@@ -524,13 +511,13 @@ export class MarkdownConverter {
 		}
 
 		// 返回结束时的 marks 状态
-		return activeMarks.filter(m => m.type === 'bold' || m.type === 'highlight' || m.type === 'italic');
+		return activeMarks.filter(m => m.type === 'bold' || m.type === 'highlight');
 	}
 
 	/**
 	 * 切换 mark 状态
 	 */
-	private toggleMark(marks: NoteAtomMark[], markType: 'bold' | 'highlight' | 'italic'): void {
+	private toggleMark(marks: NoteAtomMark[], markType: 'bold' | 'highlight'): void {
 		const index = marks.findIndex(m => m.type === markType);
 		if (index !== -1) {
 			marks.splice(index, 1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,369 +1,50 @@
-import { App, Editor, MarkdownView, Notice, Plugin, Setting, Menu, TextComponent, Modal, TFile, getFrontMatterInfo, parseYaml, stringifyYaml } from 'obsidian';
-import { MowenSettingTab, DEFAULT_SETTINGS, MowenPluginSettings } from "./settings";
-import { publishNoteToMowen, markdownTagsToNoteAtomTags, getUploadAuthorization, deliverFile, getFileType, getMimeType, getFileTypeName } from "./api";
-import { generateNoteMetadata } from "./ai"; // 导入AI生成函数
-import { TagService } from "./services/TagService";
+/**
+ * 墨问 Obsidian 插件 - 主入口
+ * 
+ * 重构项：
+ * - #1: 拆分为独立模块（Modal、Converter、FrontmatterService）
+ * - #2: 消除重复发布逻辑，提取通用方法
+ * - #13: 修复 settings.tags 污染问题
+ * - #25: 命令面板条目中文化
+ * - #27: 添加 onunload 生命周期
+ * - #28: 图片上传失败 fallback 格式修正
+ * - #29: TagService.mergeTags 参数简化
+ * - #30: 发布中禁用插件时清理逻辑
+ */
 
-// 发布弹窗 Modal - UX优化版：局部更新，避免全量重绘
-class MowenPublishModal extends Modal {
-	content: string;
+import { App, Editor, MarkdownView, Notice, Plugin, Menu, TFile } from 'obsidian';
+import { MowenSettingTab, DEFAULT_SETTINGS, MowenPluginSettings } from "./settings";
+import { publishNoteToMowen, markdownTagsToNoteAtomTags } from "./api";
+import { generateNoteMetadata } from "./ai";
+import { TagService } from "./services/TagService";
+import { FrontmatterService } from "./services/FrontmatterService";
+import { MarkdownConverter } from "./converter/MarkdownConverter";
+import { MowenPublishModal } from "./modals/MowenPublishModal";
+import { PublishContextSettings, ModalSubmitParams } from "./types";
+
+/** 发布请求参数 */
+interface PublishOptions {
 	title: string;
+	content: string;
 	tags: string;
 	autoPublish: boolean;
-	plugin: MowenPlugin; // 添加插件实例
-	initialLoadDone: boolean = false; // 添加标志，控制是否已经初始化
-	section: number = 0;
-	privacy: string = 'private';
-	noShare: boolean = false;
-	expireAt: number = 0;
-	summary: string | null = null; // 用于存储AI生成的摘要
-
-	// === UX优化：分离容器元素，避免全量重绘 ===
-	private titleInput!: TextComponent;
-	private tagsInput!: TextComponent;
-	private aiButton!: HTMLButtonElement;
-	private aiSettingEl!: HTMLElement;
-	private autoPublishToggleEl!: HTMLElement;
-	private contentPreviewEl!: HTMLElement;
-	private privacySectionContainer!: HTMLElement;
-	private publishButtonEl!: HTMLElement;
-	private errorContainer!: HTMLElement; // 验证错误显示区域
-
-	onSubmit: (title: string, tags: string, autoPublish: boolean, settings: any, summary: string | null) => void;
-
-	constructor(app: App, content: string, title: string, plugin: MowenPlugin, onSubmit: (title: string, tags: string, autoPublish: boolean, settings: any, summary: string | null) => void) {
-		super(app);
-		this.content = content;
-		this.title = title;
-		this.plugin = plugin; // 保存插件实例
-		this.onSubmit = onSubmit;
-	}
-
-	async onOpen() {
-		const { contentEl } = this;
-		contentEl.empty();
-		contentEl.createEl('h2', { text: '发布到墨问' });
-
-		// 只有在首次打开时才加载现有设置
-		if (!this.initialLoadDone) {
-			const loadedSettings = await this.plugin.getSettingsFromFrontmatter();
-			// 使用加载的设置（如果存在）初始化模态框的状态
-			this.tags = loadedSettings.tags ? loadedSettings.tags : markdownTagsToNoteAtomTags(this.content, this.plugin.settings.defaultTag).tags.join(',');
-			this.autoPublish = typeof loadedSettings.autoPublish !== 'undefined' ? loadedSettings.autoPublish : this.plugin.settings.autoPublish;
-			this.section = loadedSettings.privacy ? 1 : 0;
-			if (loadedSettings.privacy) {
-				this.privacy = loadedSettings.privacy.type;
-				if (loadedSettings.privacy.rule) {
-					this.noShare = loadedSettings.privacy.rule.noShare;
-					this.expireAt = loadedSettings.privacy.rule.expireAt;
-				}
-			}
-			this.initialLoadDone = true; // 标记为已完成初始加载
-		}
-
-		this.renderLayout(); // 渲染布局（只执行一次）
-		this.updateContentPreview(); // 更新内容预览
-		this.renderPrivacySection(); // 渲染隐私设置区域
-	}
-
-	// 工具方法：去除 YAML frontmatter
-	private stripFrontmatter(content: string): string {
-		if (content.startsWith('---')) {
-			const end = content.indexOf('\n---', 3);
-			if (end !== -1) {
-				return content.slice(end + 4).trimStart();
-			}
-		}
-		return content;
-	}
-
-	// === UX优化1：布局只渲染一次，后续只局部更新 ===
-	private renderLayout() {
-		const { contentEl } = this;
-
-		// 错误提示区域（放在最上方）
-		this.errorContainer = contentEl.createDiv({ cls: 'mowen-error-container' });
-		this.errorContainer.style.color = '#e74c3c';
-		this.errorContainer.style.marginBottom = '10px';
-
-		// 标题输入
-		new Setting(contentEl)
-			.setName('标题')
-			.setDesc('发布到墨问后的笔记标题，会自动加粗（必填）')
-			.addText((text) => {
-				this.titleInput = text;
-				text.setValue(this.title).onChange((value) => {
-					this.title = value;
-					this.validateForm();
-				});
-				text.inputEl.addEventListener('blur', () => this.validateForm());
-			});
-
-		// 标签输入
-		new Setting(contentEl)
-			.setName('标签')
-			.setDesc('可选，英文逗号分隔，发布到墨问后的笔记标签')
-			.addText((text) => {
-				this.tagsInput = text;
-				text.setValue(this.tags).onChange((value) => {
-					this.tags = value;
-					this.validateForm();
-				});
-			});
-
-		// AI功能按钮 - 独立容器，方便只更新按钮状态
-		this.aiSettingEl = contentEl.createDiv();
-		this.renderAiButton();
-
-		// 自动发布开关
-		new Setting(contentEl)
-			.setName('自动发布')
-			.setDesc('立即发布到墨问')
-			.addToggle(toggle => {
-				this.autoPublishToggleEl = toggle.toggleEl;
-				toggle.setValue(this.autoPublish).onChange(value => {
-					this.autoPublish = value;
-				});
-			});
-
-		// 内容预览 - 独立容器
-		this.contentPreviewEl = contentEl.createDiv();
-		this.updateContentPreview();
-
-		// 隐私设置区域 - 独立容器
-		new Setting(contentEl)
-			.setName('隐私设置')
-			.setDesc('设置笔记隐私')
-			.addToggle(toggle => {
-				toggle.setValue(this.section === 1).onChange(value => {
-					this.section = value ? 1 : 0;
-					this.renderPrivacySection(); // === UX优化3：只局部渲染隐私区域 ===
-				});
-			});
-		this.privacySectionContainer = contentEl.createDiv();
-
-		// 发布按钮 - 独立容器
-		this.publishButtonEl = contentEl.createDiv();
-		this.renderPublishButton();
-
-		// 初始验证
-		this.validateForm();
-	}
-
-	// === UX优化2：AI按钮独立渲染，生成时只更新按钮状态 ===
-	private renderAiButton(isGenerating: boolean = false) {
-		this.aiSettingEl.empty();
-		new Setting(this.aiSettingEl)
-			.setName('AI 功能')
-			.setDesc('使用AI为当前笔记生成标题和标签')
-			.addButton(button => {
-				this.aiButton = button.buttonEl;
-				button
-					.setButtonText(isGenerating ? '正在生成...' : '✨ AI 生成')
-					.setDisabled(isGenerating);
-				// setCta() 不接受参数，根据条件调用
-				if (!isGenerating) {
-					button.setCta();
-				}
-				button.onClick(async () => {
-					await this.handleAiGenerate();
-				});
-			});
-	}
-
-	// AI生成处理 - 只更新必要元素，不刷新整个弹窗
-	private async handleAiGenerate() {
-		// === UX优化：只更新按钮状态，不调用 renderSettings ===
-		this.renderAiButton(true);
-		new Notice('AI 正在生成内容，请稍候...');
-
-		try {
-			const cleanContent = this.stripFrontmatter(this.content);
-			const result = await generateNoteMetadata(this.plugin.settings, cleanContent);
-
-			if (result) {
-				// 只更新输入框值，不重绘整个弹窗
-				this.title = result.title;
-				this.titleInput.setValue(this.title);
-
-				const defaultTags = markdownTagsToNoteAtomTags(this.content, this.plugin.settings.defaultTag).tags;
-				const aiTags = result.tags || [];
-				const combinedTags = [...new Set([...defaultTags, ...aiTags])];
-				this.tags = combinedTags.join(',');
-				this.tagsInput.setValue(this.tags);
-
-				if (result.summary) {
-					this.summary = result.summary;
-					new Notice('AI 生成成功，摘要已保存！');
-				} else {
-					this.summary = null;
-					new Notice('AI 生成成功！');
-				}
-
-				// 只更新内容预览
-				this.updateContentPreview();
-
-				// 验证表单
-				this.validateForm();
-			}
-		} catch (error) {
-			console.error('AI生成失败:', error);
-			new Notice('AI 生成失败，请检查API配置');
-		}
-
-		// 无论成功失败，恢复按钮状态
-		this.renderAiButton(false);
-	}
-
-	// 内容预览局部更新
-	private updateContentPreview() {
-		this.contentPreviewEl.empty();
-		let previewContent = this.stripFrontmatter(this.content);
-		if (this.summary) {
-			previewContent = `> ${this.summary}\n\n${previewContent}`;
-		}
-		const previewText = previewContent.length > 100 ? previewContent.slice(0, 100) + '...' : previewContent;
-		new Setting(this.contentPreviewEl)
-			.setName('内容')
-			.setDesc(previewText);
-	}
-
-	// === UX优化3：隐私设置局部渲染 ===
-	private renderPrivacySection() {
-		this.privacySectionContainer.empty();
-
-		if (this.section === 1) {
-			// 隐私类型下拉框
-			new Setting(this.privacySectionContainer)
-				.setName('隐私类型')
-				.setDesc('设置笔记的隐私类型')
-				.addDropdown(drop => {
-					drop.addOption('private', '私有');
-					drop.addOption('public', '公开');
-					drop.addOption('rule', '规则');
-					drop.setValue(this.privacy);
-					drop.onChange(value => {
-						this.privacy = value;
-						this.renderPrivacyRuleSection(); // === 只局部渲染规则部分 ===
-					});
-				});
-
-			// 规则设置容器
-			this.renderPrivacyRuleSection();
-		}
-	}
-
-	// 隐私规则部分局部渲染
-	private renderPrivacyRuleSection() {
-		// 移除旧的规则容器（如果存在）
-		const existingRuleContainer = this.privacySectionContainer.querySelector('.privacy-rule-container');
-		if (existingRuleContainer) {
-			existingRuleContainer.remove();
-		}
-
-		if (this.privacy === 'rule') {
-			const ruleContainer = this.privacySectionContainer.createDiv({ cls: 'privacy-rule-container' });
-
-			new Setting(ruleContainer)
-				.setName('允许分享')
-				.setDesc('是否允许分享')
-				.addToggle(toggle => {
-					toggle.setValue(this.noShare).onChange(value => {
-						this.noShare = value;
-					});
-				});
-
-			new Setting(ruleContainer)
-				.setName('公开过期时间')
-				.setDesc('到期后自动变为私有，选择日期和时间')
-				.addText(text => {
-					let defaultValue = '';
-					if (this.expireAt) {
-						const date = new Date(this.expireAt * 1000);
-						defaultValue = date.toISOString().slice(0, 16);
-					}
-					text.inputEl.type = 'datetime-local';
-					text.setValue(defaultValue);
-					text.onChange((value) => {
-						if (value) {
-							this.expireAt = Math.floor(new Date(value).getTime() / 1000);
-						} else {
-							this.expireAt = 0;
-						}
-					});
-				});
-		}
-	}
-
-	// 发布按钮渲染
-	private renderPublishButton() {
-		this.publishButtonEl.empty();
-		new Setting(this.publishButtonEl)
-			.addButton((btn) =>
-				btn
-					.setButtonText('发布')
-					.setCta()
-					.onClick(() => {
-						if (this.validateForm()) {
-							this.onSubmit(
-								this.title,
-								this.tags,
-								this.autoPublish,
-								{
-									section: this.section,
-									privacy: {
-										type: this.privacy,
-										rule: {
-											noShare: this.privacy === 'rule' ? this.noShare : undefined,
-											expireAt: this.privacy === 'rule' ? this.expireAt : undefined
-										}
-									}
-								},
-								this.summary // 传递摘要
-							);
-							this.close();
-						}
-					})
-			);
-	}
-
-	// === UX优化4：表单验证 ===
-	private validateForm(): boolean {
-		this.errorContainer.empty();
-		const errors: string[] = [];
-
-		// 标题必填验证
-		if (!this.title || this.title.trim().length === 0) {
-			errors.push('❌ 标题为必填项');
-		}
-
-		// 标签格式验证（可选，但如果有内容必须符合格式）
-		if (this.tags && this.tags.trim().length > 0) {
-			// 验证标签是否用英文逗号分隔
-			const tagPattern = /^[\u4e00-\u9fa5a-zA-Z0-9_-]+(,[\u4e00-\u9fa5a-zA-Z0-9_-]+)*$/;
-			const cleanedTags = this.tags.trim();
-			if (!tagPattern.test(cleanedTags) && !cleanedTags.split(',').every(t => t.trim().length > 0)) {
-				errors.push('❌ 标签格式错误：请使用英文逗号分隔，如：技术,AI,笔记');
-			}
-		}
-
-		// 显示错误
-		if (errors.length > 0) {
-			errors.forEach(err => {
-				this.errorContainer.createEl('div', { text: err });
-			});
-			return false;
-		}
-
-		return true;
-	}
+	settings: PublishContextSettings;
+	writeNoteIdToFrontmatter: boolean;
+	summary: string | null;
+	isSelection: boolean;
 }
 
 export default class MowenPlugin extends Plugin {
-	settings: MowenPluginSettings;
+	settings!: MowenPluginSettings;
+	private frontmatterService!: FrontmatterService;
+	private markdownConverter!: MarkdownConverter;
 
 	async onload() {
 		await this.loadSettings();
+
+		// 初始化服务
+		this.frontmatterService = new FrontmatterService(this.app, this.settings);
+		this.markdownConverter = new MarkdownConverter({ app: this.app, settings: this.settings });
 
 		// 右键菜单：选中文本发布到墨问
 		this.registerEvent(
@@ -372,84 +53,28 @@ export default class MowenPlugin extends Plugin {
 				if (selectedText && selectedText.length > 0) {
 					menu.addItem((item) => {
 						item
-							.setTitle('Publish selected text to Mowen')
+							.setTitle('发布选中文本到墨问')
 							.setIcon('upload')
 							.onClick(async () => {
-								if (this.settings.globalPublishEnabled) {
-									// 合并全局标签、默认标签和笔记自身标签
-									const tags = TagService.mergeTags(
-										this.settings.globalPublishConfig.tags,
-										this.settings.defaultTag,
-										selectedText,
-										this.settings.defaultTag
-									);
-									const autoPublish = this.settings.globalPublishConfig.autoPublish;
-									const privacy = this.settings.globalPublishConfig.privacy;
-									const section = 1;
-									await this.publishToMowen(
-										'',
-										selectedText,
-										tags,
-										autoPublish,
-										{
-											section,
-											privacy
-										},
-										false,
-										null,
-										true
-									);
-								} else {
-									new MowenPublishModal(this.app, selectedText, '', this, async (title, tags, autoPublish, settings, summary) => {
-										await this.publishToMowen(title, selectedText, tags, autoPublish, settings, false, summary, true);
-									}).open();
-								}
+								await this.handlePublishRequest(selectedText, '', false, true);
 							});
 					});
 				}
 			})
 		);
 
-		// 文章菜单：整篇发布到墨问
+		// 文件菜单：整篇发布到墨问
 		this.registerEvent(
 			this.app.workspace.on('file-menu', (menu, file) => {
 				if (file instanceof TFile && file.extension === 'md') {
 					menu.addItem((item) => {
 						item
-							.setTitle('Publish to Mowen')
+							.setTitle('发布到墨问')
 							.setIcon('upload')
 							.onClick(async () => {
 								const content = await this.app.vault.read(file);
-								const title = await this.getTitleFromFile(file);
-								if (this.settings.globalPublishEnabled) {
-									// 合并全局标签、默认标签和笔记自身标签
-									const tags = TagService.mergeTags(
-										this.settings.globalPublishConfig.tags,
-										this.settings.defaultTag,
-										content,
-										this.settings.defaultTag
-									);
-									const autoPublish = this.settings.globalPublishConfig.autoPublish;
-									const privacy = this.settings.globalPublishConfig.privacy;
-									const section = 1;
-									await this.publishToMowen(
-										title,
-										content,
-										tags,
-										autoPublish,
-										{
-											section,
-											privacy
-										},
-										true,
-										null,
-										false
-									);
-								} else {
-									new MowenPublishModal(this.app, content, title, this, async (newTitle, tags, autoPublish, settings, summary) => {
-										await this.publishToMowen(newTitle, content, tags, autoPublish, settings, true, summary, false);
-									}).open();
-								}
+								const title = await this.frontmatterService.getTitleFromFile(file);
+								await this.handlePublishRequest(content, title, true, false);
 							});
 					});
 				}
@@ -459,43 +84,15 @@ export default class MowenPlugin extends Plugin {
 		// 命令面板：整篇发布到墨问
 		this.addCommand({
 			id: 'publish-current-file-to-mowen',
-			name: 'Publish to Mowen',
+			name: '发布当前文件到墨问',
 			checkCallback: (checking: boolean) => {
 				const markdownView = this.app.workspace.getActiveViewOfType(MarkdownView);
 				if (markdownView && markdownView.file) {
 					if (!checking) {
 						const file = markdownView.file;
 						const content = markdownView.editor.getValue();
-						this.getTitleFromFile(file).then(title => {
-							if (this.settings.globalPublishEnabled) {
-								// 合并全局标签、默认标签和笔记自身标签
-								const tags = TagService.mergeTags(
-									this.settings.globalPublishConfig.tags,
-									this.settings.defaultTag,
-									content,
-									this.settings.defaultTag
-								);
-								const autoPublish = this.settings.globalPublishConfig.autoPublish;
-								const privacy = this.settings.globalPublishConfig.privacy;
-								const section = 1;
-								this.publishToMowen(
-									title,
-									content,
-									tags,
-									autoPublish,
-									{
-										section,
-										privacy
-									},
-									true,
-									null,
-									false
-								);
-							} else {
-								new MowenPublishModal(this.app, content, title, this, async (newTitle, tags, autoPublish, settings, summary) => {
-									await this.publishToMowen(newTitle, content, tags, autoPublish, settings, true, summary, false);
-								}).open();
-							}
+						this.frontmatterService.getTitleFromFile(file).then(title => {
+							this.handlePublishRequest(content, title, true, false);
 						});
 					}
 					return true;
@@ -507,43 +104,15 @@ export default class MowenPlugin extends Plugin {
 		// 命令面板：选中内容发布到墨问
 		this.addCommand({
 			id: 'publish-current-selected-text-to-mowen',
-			name: 'Publish selected text to Mowen',
+			name: '发布选中文本到墨问',
 			editorCheckCallback: (checking: boolean, editor: Editor, view: MarkdownView) => {
 				const selection = editor.getSelection();
 				if (view.file && selection && selection.trim().length > 0) {
 					if (!checking) {
 						const file = view.file;
 						const content = selection;
-						this.getTitleFromFile(file).then(title => {
-							if (this.settings.globalPublishEnabled) {
-								// 合并全局标签、默认标签和笔记自身标签
-								const tags = TagService.mergeTags(
-									this.settings.globalPublishConfig.tags,
-									this.settings.defaultTag,
-									content,
-									this.settings.defaultTag
-								);
-								const autoPublish = this.settings.globalPublishConfig.autoPublish;
-								const privacy = this.settings.globalPublishConfig.privacy;
-								const section = 1;
-								this.publishToMowen(
-									title,
-									content,
-									tags,
-									autoPublish,
-									{
-										section,
-										privacy
-									},
-									false,
-									null,
-									true
-								);
-							} else {
-								new MowenPublishModal(this.app, content, title, this, async (newTitle, tags, autoPublish, settings, summary) => {
-									await this.publishToMowen(newTitle, content, tags, autoPublish, settings, false, summary, true);
-								}).open();
-							}
+						this.frontmatterService.getTitleFromFile(file).then(title => {
+							this.handlePublishRequest(content, title, false, true);
 						});
 					}
 					return true;
@@ -556,560 +125,145 @@ export default class MowenPlugin extends Plugin {
 		this.addSettingTab(new MowenSettingTab(this.app, this));
 	}
 
+	/**
+	 * 修复 #27: 添加 onunload 生命周期
+	 */
+	onunload() {
+		// 清理资源（当前没有需要清理的定时器或长连接）
+		console.log('[Mowen] 插件已卸载');
+	}
+
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData()) as MowenPluginSettings;
 	}
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+		// 设置更新后刷新服务实例
+		this.frontmatterService = new FrontmatterService(this.app, this.settings);
+		this.markdownConverter = new MarkdownConverter({ app: this.app, settings: this.settings });
 	}
 
 	/**
-	 * 将 Markdown 文本转换为 NoteAtom 结构
-	 * @param {string} markdown - Markdown 文本
-	 * @param {string} title - 笔记标题
-	 * @returns {Promise<{ content: any[] }>} NoteAtom 结构
+	 * 统一发布入口 - 修复 #2: 消除重复的发布逻辑
+	 * 所有发布入口（右键菜单、文件菜单、命令面板）都调用此方法
 	 */
-	async markdownToNoteAtom(title: string, markdown: string, summary: string | null = null): Promise<{ content: any[] }> {
-		// Skip frontmatter using Obsidian's getFrontMatterInfo
-		let contentToProcess = markdown;
-		const frontMatterInfo = getFrontMatterInfo(markdown);
-		if (frontMatterInfo.exists) {
-			// Remove frontmatter from content to process
-			contentToProcess = markdown.slice(frontMatterInfo.contentStart);
-		}
+	private async handlePublishRequest(
+		content: string,
+		title: string,
+		isWholeFile: boolean,
+		isSelection: boolean
+	): Promise<void> {
+		if (this.settings.globalPublishEnabled) {
+			// 全局发布模式：直接发布，不弹窗
+			const tags = TagService.mergeTags(
+				this.settings.globalPublishConfig.tags,
+				this.settings.defaultTag,
+				content
+			);
+			const autoPublish = this.settings.globalPublishConfig.autoPublish;
+			const privacy = this.settings.globalPublishConfig.privacy;
 
-		const lines = contentToProcess.split('\n');
-		const content = [];
-		content.push({
-			type: 'paragraph',
-			content: [
-				{ type: 'text', text: title, marks: [{ type: 'bold' }] }
-			]
-		});
-		// title 后面增加一个空行
-		content.push({ type: 'paragraph' });
-
-		// 如果有摘要，将其作为引用块添加到标题下方
-		if (summary) {
-			content.push({
-				type: 'quote',
-				content: [{ type: 'text', text: summary }]
+			await this.publishToMowen({
+				title,
+				content,
+				tags,
+				autoPublish,
+				settings: {
+					section: 1,
+					privacy
+				},
+				writeNoteIdToFrontmatter: isWholeFile,
+				summary: null,
+				isSelection
 			});
-			content.push({ type: 'paragraph' }); // 摘要后也添加空行
-		}
-
-		let inQuote = false;
-		let quoteBuffer = [];
-		let inCode = false;
-
-		for (let i = 0; i < lines.length; i++) {
-			let line = lines[i].trim();
-			if (line.startsWith('```')) {
-				inCode = !inCode;
-				continue; // 跳过代码块的三个反引号行
-			}
-			if (inCode) {
-				// 如果在代码块内，直接添加为普通文本
-				content.push({
-					type: 'paragraph',
-					content: [{ type: 'text', text: line + '\n' }] // 代码块内保持单行
-				});
-				continue;
-			}
-
-			// 1. 引用块
-			if (line.startsWith('>')) {
-				inQuote = true;
-				quoteBuffer.push(line.replace(/^>\s*/, '').trim()); // 移除 > 和可能的空格
-				continue;
-			}
-			// 检查是否还在引用块内（或者引用块结束）
-			if (inQuote && (line.startsWith('>') || line !== '')) {
-				quoteBuffer.push(line.replace(/^>\s*/, '').trim());
-				continue;
-			}
-			if (inQuote && !line.startsWith('>') && line === '') {
-				// 结束引用
-				content.push({
-					type: 'quote',
-					content: [
-						{
-							type: 'text',
-							text: quoteBuffer.join('\n')
-						}
-					]
-				});
-				content.push({ type: 'paragraph' }); // 引用后添加空行
-				quoteBuffer = [];
-				inQuote = false;
-			}
-
-			// 2. 图片或内嵌笔记
-			const embedMatch = line.match(/^!\[\[(.+?)\]\]/);
-			const embedMatch2 = line.match(/^\[\[(.+?)\]\]/);
-			if (embedMatch || embedMatch2) {
-				let linkText = ""; // 获取链接文本，如 "My Note" 或 "images/photo.png"
-				if (embedMatch) {
-					linkText = embedMatch[1];
-				} else if (embedMatch2) {
-					linkText = embedMatch2[1];
-				}
-
-				let file: TFile | null = null;
-
-				// 使用 Obsidian API 来解析链接，这是最可靠的方法
-				const currentActiveFile = this.app.workspace.getActiveFile();
-				const sourcePath = currentActiveFile ? currentActiveFile.path : '';
-				if (linkText) {
-					file = this.app.metadataCache.getFirstLinkpathDest(linkText, sourcePath);
-				}
-
-				if (file instanceof TFile) {
-					const fullPath = file.path;
-					// 判断文件类型
-					if (file.extension.toLowerCase() === 'md') {
-						// 处理内嵌的 Markdown 文件
-						new Notice(`正在处理内嵌笔记: ${fullPath}`);
-						const noteId = this.getNoteIdFromFileCache(file);
-						if (noteId) {
-							content.push({
-								type: 'note',
-								attrs: {
-									uuid: noteId
-								}
-							});
-							new Notice(`成功嵌入笔记: ${file.name}`);
-						} else {
-							new Notice(`内嵌笔记 ${file.name} 未找到 noteId，将作为普通文本插入`);
-							content.push({
-								type: 'paragraph',
-								content: [{ type: 'text', text: `[[${linkText}]]` }]
-							});
-						}
-					} else {
-						// 处理图片文件（沿用现有逻辑）
-						new Notice(`正在上传图片: ${fullPath}`);
-						const mimeType = getMimeType(file.extension);
-						const fileBlob = new Blob([await this.app.vault.readBinary(file)], { type: mimeType });
-						const fName = file.name;
-						const fileType = getFileType(file.extension);
-						const fileTypeName = getFileTypeName(fileType);
-						const authRes = await getUploadAuthorization(this.settings.apiKey, fileType);
-						if (authRes.success && authRes.data && authRes.data.endpoint) {
-							const uploadRes = await deliverFile(authRes.data.endpoint, authRes.data as Record<string, string>, fileBlob, fName);
-							if (uploadRes.success && uploadRes.data) {
-								let uuidKey = fileType == 2 ? 'audio-uuid' : 'uuid';
-								let attr = {
-									[uuidKey]: uploadRes.data.file?.fileId || '',
-									align: 'center',
-									alt: fName
-								};
-								content.push({
-									type: fileTypeName,
-									attrs: attr
-								});
-								new Notice(`图片上传成功: ${fName}`);
-							} else {
-								new Notice(`图片上传失败: ${fName} - ${uploadRes.message}`);
-								content.push({ type: 'paragraph', content: [{ type: 'text', text: `![[${linkText}]]` }] });
-							}
-						} else {
-							new Notice(`获取图片上传授权失败: ${authRes.message}`);
-							content.push({ type: 'paragraph', content: [{ type: 'text', text: `![[${linkText}]]` }] });
-						}
-					}
-				} else {
-					new Notice(`文件未找到: ${linkText}`);
-					content.push({
-						type: 'paragraph',
-						content: [{ type: 'text', text: `![[${linkText}]]` }]
+		} else {
+			// 弹窗模式
+			new MowenPublishModal(
+				this.app,
+				content,
+				title,
+				{ settings: this.settings, getSettingsFromFrontmatter: () => this.frontmatterService.getSettingsFromFrontmatter() },
+				async (params: ModalSubmitParams) => {
+					await this.publishToMowen({
+						title: params.title,
+						content,
+						tags: params.tags,
+						autoPublish: params.autoPublish,
+						settings: params.settings,
+						writeNoteIdToFrontmatter: isWholeFile,
+						summary: params.summary,
+						isSelection
 					});
 				}
-				continue;
-			}
-
-			// 3. 标题
-			const headingMatch = line.match(/^(#+)\s*(.+)$/);
-			if (headingMatch) {
-				content.push({
-					type: 'paragraph',
-					content: [
-						{
-							type: 'text',
-							text: headingMatch[2],
-							marks: [{ type: 'bold' }] // 标题默认加粗
-						}
-					]
-				});
-				continue;
-			}
-
-			// 4. 处理普通文本（包括加粗、高亮和链接的组合）
-			if (line !== '') {
-				const parts: { type: string; text: string; marks: any[] }[] = [];
-				const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
-				let lastIndex = 0;
-				let match;
-				
-				// 跟踪当前的 bold/highlight 状态（用于链接叠加）
-				let currentFormatMarks: any[] = [];
-
-				while ((match = linkRegex.exec(line)) !== null) {
-					// 处理链接前的文本（包括 ** 和 == 标记）
-					if (match.index > lastIndex) {
-						const textBeforeLink = line.slice(lastIndex, match.index);
-						// processBoldText 会处理格式标记并返回结束时的状态
-						currentFormatMarks = this.processBoldText(textBeforeLink, parts, []);
-					}
-					
-					// 处理链接：叠加外层的 bold/highlight 状态
-					const linkText = match[1];
-					const linkHref = match[2];
-					const linkMark = { type: 'link', attrs: { href: linkHref } };
-					
-					// 组合 marks：外层格式 + link
-					const combinedMarks = [...currentFormatMarks, linkMark];
-					
-					// 处理链接文本内部可能的格式标记（如 [**链接**](url)）
-					this.processBoldText(linkText, parts, combinedMarks);
-					
-					lastIndex = match.index + match[0].length;
-				}
-
-				// 处理链接后的剩余文本
-				if (lastIndex < line.length) {
-					const remainingText = line.slice(lastIndex);
-					this.processBoldText(remainingText, parts, currentFormatMarks);
-				}
-
-				if (parts.length > 0) {
-					content.push({
-						type: 'paragraph',
-						content: parts
-					});
-					content.push({ type: 'paragraph' }); // 添加段落换行
-				}
-			}
+			).open();
 		}
-
-		return { content: content };
 	}
 
 	/**
-	 * 辅助函数：处理文本格式化标记，支持 marks 数组叠加
-	 * @param textSegment - 文本片段
-	 * @param partsArray - 输出的 NoteAtom parts 数组
-	 * @param baseMarks - 基础 marks 数组（如 link），用于叠加 bold/highlight
-	 * @returns 结束时的 marks 状态（用于传递给下一个处理）
-	 * 
-	 * 支持场景：
-	 * - **普通加粗** → marks: [{ type: 'bold' }]
-	 * - ==高亮文本== → marks: [{ type: 'highlight' }]
-	 * - **==加粗高亮==** → marks: [{ type: 'bold' }, { type: 'highlight' }]
-	 * - **[链接](url)** → marks: [{ type: 'bold' }, { type: 'link', attrs: { href: 'url' } }]
+	 * 核心发布方法
+	 * 修复 #13: 不再直接修改传入的 settings 对象
 	 */
-	processBoldText(textSegment: string, partsArray: any[], baseMarks: any[] = []): any[] {
-		let currentText = '';
-		// 当前激活的 marks，从 baseMarks 开始叠加
-		let activeMarks: any[] = [...baseMarks];
-		
-		let i = 0;
-		while (i < textSegment.length) {
-			// 检测 highlight 标记 (==text==)
-			if (textSegment[i] === '=' && textSegment[i + 1] === '=') {
-				// 先推送已累积的文本
-				if (currentText) {
-					partsArray.push({
-						type: 'text',
-						text: currentText,
-						marks: activeMarks.length > 0 ? [...activeMarks] : [...baseMarks]
-					});
-					currentText = '';
-				}
-				
-				// 切换 highlight 状态
-				const highlightIndex = activeMarks.findIndex(m => m.type === 'highlight');
-				if (highlightIndex !== -1) {
-					activeMarks.splice(highlightIndex, 1);
-				} else {
-					activeMarks.push({ type: 'highlight' });
-				}
-				
-				i += 2; // 跳过 ==
-				continue;
-			}
-			
-			// 检测 bold 标记 (**)
-			if (textSegment[i] === '*' && textSegment[i + 1] === '*') {
-				// 先推送已累积的文本
-				if (currentText) {
-					partsArray.push({
-						type: 'text',
-						text: currentText,
-						marks: activeMarks.length > 0 ? [...activeMarks] : [...baseMarks]
-					});
-					currentText = '';
-				}
-				
-				// 切换 bold 状态
-				const boldIndex = activeMarks.findIndex(m => m.type === 'bold');
-				if (boldIndex !== -1) {
-					activeMarks.splice(boldIndex, 1);
-				} else {
-					activeMarks.push({ type: 'bold' });
-				}
-				
-				i += 2; // 跳过 **
-				continue;
-			}
-			
-			currentText += textSegment[i];
-			i++;
-		}
-		
-		// 处理末尾剩余文本
-		if (currentText) {
-			partsArray.push({
-				type: 'text',
-				text: currentText,
-				marks: activeMarks.length > 0 ? [...activeMarks] : [...baseMarks]
-			});
-		}
-		
-		// 返回结束时的 marks 状态（用于传递给链接处理）
-		return activeMarks.filter(m => m.type === 'bold' || m.type === 'highlight');
-	}
-
-	async publishToMowen(title: string, content: string, tags: string, autoPublish: boolean, settings: any, writeNoteIdToFrontmatter: boolean = true, summary: string | null = null, isSelection: boolean = false) {
+	async publishToMowen(options: PublishOptions): Promise<void> {
+		const { title, content, tags, autoPublish, settings, writeNoteIdToFrontmatter, summary, isSelection } = options;
 		const apiKey = this.settings.apiKey;
 		if (!apiKey) {
 			new Notice('请先在设置中填写 API key');
 			return;
 		}
+
 		const tagArr = tags.split(',').map(t => t.trim()).filter(Boolean);
 		new Notice('正在发布到墨问...');
 
-		// 对于选中文本发布，不传递 noteId，因为这是新笔记
+		// 对于选中文本发布，不传递 noteId
 		let noteId: string | null;
 		if (isSelection) {
 			noteId = null;
 		} else {
-			noteId = await this.getNoteIdFromFrontmatter(content);
+			noteId = await this.frontmatterService.getNoteIdFromContent(content);
 		}
 
-		settings.tags = tags;
-		// 在这里调用移动后的 markdownToNoteAtom
-		const noteBody = await this.markdownToNoteAtom(title, content, summary);
+		// 使用 MarkdownConverter 转换内容
+		const noteBody = await this.markdownConverter.convert(title, content, summary);
+
+		// 修复 #13: 创建 settings 副本，不污染原始对象
+		const publishSettings = {
+			auto_publish: autoPublish,
+			tags: tagArr,
+			privacy: {
+				type: settings.privacy.type,
+				rule: settings.privacy.rule
+			},
+			section: settings.section
+		};
 
 		const res = await publishNoteToMowen({
 			noteId,
 			apiKey,
-			title, // 实际API可能不需要 title，body里已经有了
-			content: '', // 内容通过 body 字段传递
+			title,
+			content: '',
 			tags: tagArr,
 			autoPublish,
-			settings: {
-				auto_publish: autoPublish, // 确保字段名正确
-				tags: tagArr, // 确保字段名正确
-				privacy: {
-					type: settings.privacy.type,
-					rule: settings.privacy.rule
-				},
-				section: settings.section
-			},
-			body: noteBody.content // 传递转换后的 NoteAtom 内容
+			settings: publishSettings,
+			body: noteBody.content
 		});
 
 		if (res.success && res.data) {
 			new Notice('发布成功！');
 			if (writeNoteIdToFrontmatter) {
-				await this.addNoteIdToFrontmatter(res.data, settings);
+				const frontmatterSettings: PublishContextSettings = {
+					section: settings.section,
+					privacy: settings.privacy,
+					tags: tags,
+					auto_publish: autoPublish
+				};
+				await this.frontmatterService.addNoteIdToFrontmatter(
+					res.data as string,
+					frontmatterSettings
+				);
 			}
 		} else {
 			new Notice('发布失败：' + res.message);
 		}
-	}
-
-	async addNoteIdToFrontmatter(noteId: string, settings: any) {
-		const activeFile = this.app.workspace.getActiveFile();
-		if (!activeFile) return;
-
-		// 更新或添加 noteId，使用用户自定义的键名
-		const noteIdKey = this.settings.noteIdKey || 'noteId';
-
-		// 使用 processFrontMatter 来修改 frontmatter
-		await this.app.fileManager.processFrontMatter(activeFile, (fm) => {
-			// 添加或更新 noteId
-			fm[noteIdKey] = noteId;
-
-			// 更新或添加其他设置
-			if (settings) {
-				if (settings.tags) {
-					fm.mowenTags = settings.tags; // 使用单独的字段避免与 Obsidian 自身标签冲突
-				}
-				if (typeof settings.auto_publish !== 'undefined') {
-					fm.mowenAutoPublish = settings.auto_publish;
-				}
-				if (settings.privacy) {
-					fm.mowenPrivacyType = settings.privacy.type;
-					if (settings.privacy.rule) {
-						fm.mowenPrivacyNoShare = settings.privacy.rule.noShare;
-						fm.mowenPrivacyExpireAt = settings.privacy.rule.expireAt;
-					}
-				}
-			}
-		});
-	}
-
-	/**
-	 * Get note ID from file frontmatter using MetadataCache
-	 */
-	getNoteIdFromFileCache(file: TFile): string | null {
-		const fileCache = this.app.metadataCache.getFileCache(file);
-		const frontmatterObj = fileCache?.frontmatter || {};
-
-		const customKey = this.settings.noteIdKey || 'noteId';
-		const defaultKey = 'noteId';
-
-		// 根据设置，决定要检查哪些key
-		const keysToCheck: string[] = [customKey];
-		if (this.settings.enableLegacyNoteIdFallback && customKey !== defaultKey) {
-			keysToCheck.push(defaultKey);
-		}
-
-		for (const key of keysToCheck) {
-			if (frontmatterObj[key]) {
-				return frontmatterObj[key];
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Get note ID from frontmatter using MetadataCache (useful for selections)
-	 */
-	getNoteIdFromCache(): string | null {
-		const frontmatterObj = this.getFrontmatterFromCache();
-
-		const customKey = this.settings.noteIdKey || 'noteId';
-		const defaultKey = 'noteId';
-
-		// 根据设置，决定要检查哪些key
-		const keysToCheck: string[] = [customKey];
-		if (this.settings.enableLegacyNoteIdFallback && customKey !== defaultKey) {
-			keysToCheck.push(defaultKey);
-		}
-
-		for (const key of keysToCheck) {
-			if (frontmatterObj[key]) {
-				return frontmatterObj[key];
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Get frontmatter from active file using MetadataCache (useful for selections)
-	 */
-	getFrontmatterFromCache(): any {
-		const activeFile = this.app.workspace.getActiveFile();
-		if (!activeFile) return {};
-
-		const fileCache = this.app.metadataCache.getFileCache(activeFile);
-		return fileCache?.frontmatter || {};
-	}
-
-	async getSettingsFromFrontmatter(): Promise<any> {
-		const activeFile = this.app.workspace.getActiveFile();
-		if (!activeFile) return {};
-
-		// 使用 MetadataCache 获取 frontmatter，避免从磁盘读取文件内容
-		const fileCache = this.app.metadataCache.getFileCache(activeFile);
-		const frontmatterObj = fileCache?.frontmatter || {};
-
-		const loadedSettings: any = {};
-		// 加载标签
-		if (frontmatterObj.mowenTags) {
-			loadedSettings.tags = frontmatterObj.mowenTags;
-		}
-		// 加载自动发布
-		if (typeof frontmatterObj.mowenAutoPublish !== 'undefined') {
-			loadedSettings.autoPublish = frontmatterObj.mowenAutoPublish;
-		}
-		// 加载隐私设置
-		if (frontmatterObj.mowenPrivacyType) {
-			loadedSettings.privacy = {
-				type: frontmatterObj.mowenPrivacyType,
-				rule: {
-					noShare: frontmatterObj.mowenPrivacyNoShare || false,
-					expireAt: frontmatterObj.mowenPrivacyExpireAt || 0,
-				}
-			};
-		}
-		return loadedSettings;
-	}
-
-	/**
-	 * 从 frontmatter 中获取 noteId，存在则更新笔记，不存在则创建笔记
-	 * @returns {string | null}
-	 */
-	async getNoteIdFromFrontmatter(content: string): Promise<string | null> {
-		const customKey = this.settings.noteIdKey || 'noteId';
-		const defaultKey = 'noteId';
-
-		// 根据设置，决定要检查哪些key
-		const keysToCheck: string[] = [customKey];
-		if (this.settings.enableLegacyNoteIdFallback && customKey !== defaultKey) {
-			keysToCheck.push(defaultKey);
-		}
-
-		// 使用 Obsidian 的 getFrontMatterInfo 获取 frontmatter 信息
-		const frontMatterInfo = getFrontMatterInfo(content);
-
-		if (frontMatterInfo.exists) {
-			try {
-				// 使用 parseYaml 解析 frontmatter
-				const frontmatterObj = parseYaml(frontMatterInfo.frontmatter);
-
-				if (frontmatterObj && typeof frontmatterObj === 'object') {
-					for (const key of keysToCheck) {
-						if (frontmatterObj[key]) {
-							return frontmatterObj[key];
-						}
-					}
-				}
-			} catch (e) {
-				console.error('解析 frontmatter 失败:', e);
-				// 如果解析失败，回退到简单的正则匹配
-				for (const key of keysToCheck) {
-					const regex = new RegExp(`^${key}:\\s*(\\S+)`, 'm');
-					const match = frontMatterInfo.frontmatter.match(regex);
-					if (match) return match[1];
-				}
-			}
-		}
-
-		return null;
-	}
-
-	async getTitleFromFile(file: TFile): Promise<string> {
-		const titleKey = this.settings.titleKey;
-		if (!titleKey) {
-			return file.basename;
-		}
-
-		// 使用 MetadataCache 获取 frontmatter，避免从磁盘读取文件内容
-		const fileCache = this.app.metadataCache.getFileCache(file);
-		const frontmatterObj = fileCache?.frontmatter || {};
-
-		if (frontmatterObj[titleKey]) {
-			return frontmatterObj[titleKey];
-		}
-
-		// 如果没有找到key，回退到文件名
-		return file.basename;
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,25 +226,17 @@ export default class MowenPlugin extends Plugin {
 		// 使用 MarkdownConverter 转换内容
 		const noteBody = await this.markdownConverter.convert(title, content, summary);
 
-		// 修复 #13: 创建 settings 副本，不污染原始对象
-		const publishSettings = {
-			auto_publish: autoPublish,
-			tags: tagArr,
-			privacy: {
-				type: settings.privacy.type,
-				rule: settings.privacy.rule
-			},
-			section: settings.section
-		};
-
+		// 按官方文档构建发布参数
+		// 创建接口只需要 autoPublish + tags，隐私设置走独立的 /note/set
 		const res = await publishNoteToMowen({
 			noteId,
 			apiKey,
-			title,
-			content: '',
 			tags: tagArr,
 			autoPublish,
-			settings: publishSettings,
+			settings: {
+				section: settings.section,
+				privacy: settings.privacy
+			},
 			body: noteBody.content
 		});
 

--- a/src/modals/MowenPublishModal.ts
+++ b/src/modals/MowenPublishModal.ts
@@ -1,0 +1,355 @@
+/**
+ * 发布弹窗 Modal
+ * 
+ * 修复项：
+ * - #1: 从 main.ts 拆分独立文件
+ * - #24: 添加 mowen-publish-modal CSS class
+ * - #26: 错误提示使用 CSS 变量替代硬编码颜色
+ */
+
+import { App, Modal, Notice, Setting, TextComponent } from 'obsidian';
+import { MowenPluginSettings } from '../settings';
+import { PublishContextSettings, ModalSubmitParams } from '../types';
+import { markdownTagsToNoteAtomTags } from '../api';
+import { generateNoteMetadata } from '../ai';
+import { MarkdownConverter } from '../converter/MarkdownConverter';
+
+class MowenPublishModal extends Modal {
+	content: string;
+	title: string;
+	tags: string;
+	autoPublish: boolean;
+	plugin: { settings: MowenPluginSettings; getSettingsFromFrontmatter: () => Promise<Partial<PublishContextSettings>> };
+	initialLoadDone: boolean = false;
+	section: number = 0;
+	privacy: string = 'private';
+	noShare: boolean = false;
+	expireAt: number = 0;
+	summary: string | null = null;
+
+	// === UX优化：分离容器元素 ===
+	private titleInput!: TextComponent;
+	private tagsInput!: TextComponent;
+	private aiButton!: HTMLButtonElement;
+	private aiSettingEl!: HTMLElement;
+	private autoPublishToggleEl!: HTMLElement;
+	private contentPreviewEl!: HTMLElement;
+	private privacySectionContainer!: HTMLElement;
+	private publishButtonEl!: HTMLElement;
+	private errorContainer!: HTMLElement;
+
+	onSubmit: (params: ModalSubmitParams) => void;
+
+	constructor(
+		app: App,
+		content: string,
+		title: string,
+		plugin: { settings: MowenPluginSettings; getSettingsFromFrontmatter: () => Promise<Partial<PublishContextSettings>> },
+		onSubmit: (params: ModalSubmitParams) => void
+	) {
+		super(app);
+		this.content = content;
+		this.title = title;
+		this.plugin = plugin;
+		this.onSubmit = onSubmit;
+	}
+
+	async onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+
+		// 修复 #24：添加 CSS class
+		contentEl.addClass('mowen-publish-modal');
+
+		contentEl.createEl('h2', { text: '发布到墨问' });
+
+		// 首次打开时加载现有设置
+		if (!this.initialLoadDone) {
+			const loadedSettings = await this.plugin.getSettingsFromFrontmatter();
+			this.tags = loadedSettings.tags
+				? loadedSettings.tags
+				: markdownTagsToNoteAtomTags(this.content, this.plugin.settings.defaultTag).tags.join(',');
+			this.autoPublish = typeof loadedSettings.auto_publish !== 'undefined'
+				? loadedSettings.auto_publish
+				: this.plugin.settings.autoPublish;
+			this.section = loadedSettings.privacy ? 1 : 0;
+			if (loadedSettings.privacy) {
+				this.privacy = loadedSettings.privacy.type;
+				if (loadedSettings.privacy.rule) {
+					this.noShare = loadedSettings.privacy.rule.noShare ?? false;
+					this.expireAt = loadedSettings.privacy.rule.expireAt ?? 0;
+				}
+			}
+			this.initialLoadDone = true;
+		}
+
+		this.renderLayout();
+		this.updateContentPreview();
+		this.renderPrivacySection();
+	}
+
+	// 工具方法：去除 YAML frontmatter
+	private stripFrontmatter(content: string): string {
+		const converter = new MarkdownConverter({ app: this.app, settings: this.plugin.settings });
+		return converter.stripFrontmatter(content);
+	}
+
+	private renderLayout() {
+		const { contentEl } = this;
+
+		// 修复 #26：错误提示使用 CSS 变量
+		this.errorContainer = contentEl.createDiv({ cls: 'mowen-error-container' });
+
+		// 标题输入
+		new Setting(contentEl)
+			.setName('标题')
+			.setDesc('发布到墨问后的笔记标题，会自动加粗（必填）')
+			.addText((text) => {
+				this.titleInput = text;
+				text.setValue(this.title).onChange((value) => {
+					this.title = value;
+					this.validateForm();
+				});
+				text.inputEl.addEventListener('blur', () => this.validateForm());
+			});
+
+		// 标签输入
+		new Setting(contentEl)
+			.setName('标签')
+			.setDesc('可选，英文逗号分隔，发布到墨问后的笔记标签')
+			.addText((text) => {
+				this.tagsInput = text;
+				text.setValue(this.tags).onChange((value) => {
+					this.tags = value;
+					this.validateForm();
+				});
+			});
+
+		// AI 功能按钮
+		this.aiSettingEl = contentEl.createDiv();
+		this.renderAiButton();
+
+		// 自动发布开关
+		new Setting(contentEl)
+			.setName('自动发布')
+			.setDesc('立即发布到墨问')
+			.addToggle(toggle => {
+				this.autoPublishToggleEl = toggle.toggleEl;
+				toggle.setValue(this.autoPublish).onChange(value => {
+					this.autoPublish = value;
+				});
+			});
+
+		// 内容预览
+		this.contentPreviewEl = contentEl.createDiv();
+		this.updateContentPreview();
+
+		// 隐私设置
+		new Setting(contentEl)
+			.setName('隐私设置')
+			.setDesc('设置笔记隐私')
+			.addToggle(toggle => {
+				toggle.setValue(this.section === 1).onChange(value => {
+					this.section = value ? 1 : 0;
+					this.renderPrivacySection();
+				});
+			});
+		this.privacySectionContainer = contentEl.createDiv();
+
+		// 发布按钮
+		this.publishButtonEl = contentEl.createDiv();
+		this.renderPublishButton();
+
+		this.validateForm();
+	}
+
+	private renderAiButton(isGenerating: boolean = false) {
+		this.aiSettingEl.empty();
+		new Setting(this.aiSettingEl)
+			.setName('AI 功能')
+			.setDesc('使用AI为当前笔记生成标题和标签')
+			.addButton(button => {
+				this.aiButton = button.buttonEl;
+				button
+					.setButtonText(isGenerating ? '正在生成...' : '✨ AI 生成')
+					.setDisabled(isGenerating);
+				if (!isGenerating) {
+					button.setCta();
+				}
+				button.onClick(async () => {
+					await this.handleAiGenerate();
+				});
+			});
+	}
+
+	private async handleAiGenerate() {
+		this.renderAiButton(true);
+		new Notice('AI 正在生成内容，请稍候...');
+
+		try {
+			const cleanContent = this.stripFrontmatter(this.content);
+			const result = await generateNoteMetadata(this.plugin.settings, cleanContent);
+
+			if (result) {
+				this.title = result.title;
+				this.titleInput.setValue(this.title);
+
+				const defaultTags = markdownTagsToNoteAtomTags(this.content, this.plugin.settings.defaultTag).tags;
+				const aiTags = result.tags || [];
+				const combinedTags = [...new Set([...defaultTags, ...aiTags])];
+				this.tags = combinedTags.join(',');
+				this.tagsInput.setValue(this.tags);
+
+				if (result.summary) {
+					this.summary = result.summary;
+					new Notice('AI 生成成功，摘要已保存！');
+				} else {
+					this.summary = null;
+					new Notice('AI 生成成功！');
+				}
+
+				this.updateContentPreview();
+				this.validateForm();
+			}
+		} catch (error) {
+			console.error('AI生成失败:', error);
+			new Notice('AI 生成失败，请检查API配置');
+		}
+
+		this.renderAiButton(false);
+	}
+
+	private updateContentPreview() {
+		this.contentPreviewEl.empty();
+		let previewContent = this.stripFrontmatter(this.content);
+		if (this.summary) {
+			previewContent = `> ${this.summary}\n\n${previewContent}`;
+		}
+		const previewText = previewContent.length > 100 ? previewContent.slice(0, 100) + '...' : previewContent;
+		new Setting(this.contentPreviewEl)
+			.setName('内容')
+			.setDesc(previewText);
+	}
+
+	private renderPrivacySection() {
+		this.privacySectionContainer.empty();
+
+		if (this.section === 1) {
+			new Setting(this.privacySectionContainer)
+				.setName('隐私类型')
+				.setDesc('设置笔记的隐私类型')
+				.addDropdown(drop => {
+					drop.addOption('private', '私有');
+					drop.addOption('public', '公开');
+					drop.addOption('rule', '规则');
+					drop.setValue(this.privacy);
+					drop.onChange(value => {
+						this.privacy = value;
+						this.renderPrivacyRuleSection();
+					});
+				});
+
+			this.renderPrivacyRuleSection();
+		}
+	}
+
+	private renderPrivacyRuleSection() {
+		const existingRuleContainer = this.privacySectionContainer.querySelector('.privacy-rule-container');
+		if (existingRuleContainer) {
+			existingRuleContainer.remove();
+		}
+
+		if (this.privacy === 'rule') {
+			const ruleContainer = this.privacySectionContainer.createDiv({ cls: 'privacy-rule-container' });
+
+			new Setting(ruleContainer)
+				.setName('允许分享')
+				.setDesc('是否允许分享')
+				.addToggle(toggle => {
+					toggle.setValue(this.noShare).onChange(value => {
+						this.noShare = value;
+					});
+				});
+
+			new Setting(ruleContainer)
+				.setName('公开过期时间')
+				.setDesc('到期后自动变为私有，选择日期和时间')
+				.addText(text => {
+					let defaultValue = '';
+					if (this.expireAt) {
+						const date = new Date(this.expireAt * 1000);
+						defaultValue = date.toISOString().slice(0, 16);
+					}
+					text.inputEl.type = 'datetime-local';
+					text.setValue(defaultValue);
+					text.onChange((value) => {
+						if (value) {
+							this.expireAt = Math.floor(new Date(value).getTime() / 1000);
+						} else {
+							this.expireAt = 0;
+						}
+					});
+				});
+		}
+	}
+
+	private renderPublishButton() {
+		this.publishButtonEl.empty();
+		new Setting(this.publishButtonEl)
+			.addButton((btn) =>
+				btn
+					.setButtonText('发布')
+					.setCta()
+					.onClick(() => {
+						if (this.validateForm()) {
+							this.onSubmit({
+								title: this.title,
+								tags: this.tags,
+								autoPublish: this.autoPublish,
+								settings: {
+									section: this.section,
+									privacy: {
+										type: this.privacy as 'private' | 'public' | 'rule',
+										rule: {
+											noShare: this.privacy === 'rule' ? this.noShare : undefined,
+											expireAt: this.privacy === 'rule' ? this.expireAt : undefined
+										}
+									}
+								},
+								summary: this.summary
+							});
+							this.close();
+						}
+					})
+			);
+	}
+
+	private validateForm(): boolean {
+		this.errorContainer.empty();
+		const errors: string[] = [];
+
+		if (!this.title || this.title.trim().length === 0) {
+			errors.push('❌ 标题为必填项');
+		}
+
+		// 修复 #14：放宽标签验证，支持更多字符
+		if (this.tags && this.tags.trim().length > 0) {
+			const tagParts = this.tags.split(',').map(t => t.trim()).filter(Boolean);
+			const invalidTags = tagParts.filter(t => !/^[\u4e00-\u9fa5a-zA-Z0-9_.\-\s]+$/.test(t));
+			if (invalidTags.length > 0) {
+				errors.push('❌ 标签格式错误：请使用英文逗号分隔，如：技术,AI,笔记');
+			}
+		}
+
+		if (errors.length > 0) {
+			errors.forEach(err => {
+				this.errorContainer.createEl('div', { text: err });
+			});
+			return false;
+		}
+
+		return true;
+	}
+}
+
+export { MowenPublishModal };

--- a/src/services/FrontmatterService.ts
+++ b/src/services/FrontmatterService.ts
@@ -1,0 +1,188 @@
+/**
+ * Frontmatter 操作服务
+ * 集中管理所有 frontmatter 相关的读写操作
+ */
+
+import { App, TFile, getFrontMatterInfo, parseYaml } from 'obsidian';
+import { MowenPluginSettings } from '../settings';
+import { PublishContextSettings } from '../types';
+
+export class FrontmatterService {
+	constructor(
+		private app: App,
+		private settings: MowenPluginSettings
+	) {}
+
+	/**
+	 * 从文件缓存获取 noteId
+	 */
+	getNoteIdFromFileCache(file: TFile): string | null {
+		const fileCache = this.app.metadataCache.getFileCache(file);
+		const frontmatterObj: Record<string, unknown> = fileCache?.frontmatter || {};
+		
+		const keysToCheck = this.getNoteIdKeys();
+		
+		for (const key of keysToCheck) {
+			const value = frontmatterObj[key];
+			if (value) {
+				return String(value);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * 从当前活动文件的缓存获取 noteId
+	 */
+	getNoteIdFromCache(): string | null {
+		const frontmatterObj = this.getFrontmatterFromCache();
+		const keysToCheck = this.getNoteIdKeys();
+		
+		for (const key of keysToCheck) {
+			const value = frontmatterObj[key];
+			if (value) {
+				return String(value);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * 从 Markdown 内容中解析 noteId（用于选中文本场景）
+	 */
+	async getNoteIdFromContent(content: string): Promise<string | null> {
+		const keysToCheck = this.getNoteIdKeys();
+
+		const frontMatterInfo = getFrontMatterInfo(content);
+
+		if (frontMatterInfo.exists) {
+			try {
+				const frontmatterObj = parseYaml(frontMatterInfo.frontmatter);
+
+				if (frontmatterObj && typeof frontmatterObj === 'object') {
+					for (const key of keysToCheck) {
+						if (frontmatterObj[key]) {
+							return frontmatterObj[key];
+						}
+					}
+				}
+			} catch (e) {
+				console.error('解析 frontmatter 失败:', e);
+				// 如果解析失败，回退到简单的正则匹配
+				for (const key of keysToCheck) {
+					const regex = new RegExp(`^${key}:\\s*(\\S+)`, 'm');
+					const match = frontMatterInfo.frontmatter.match(regex);
+					if (match) return match[1];
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * 将 noteId 和发布设置回写到 frontmatter
+	 */
+	async addNoteIdToFrontmatter(noteId: string, settings: PublishContextSettings): Promise<void> {
+		const activeFile = this.app.workspace.getActiveFile();
+		if (!activeFile) return;
+
+		const noteIdKey = this.settings.noteIdKey || 'noteId';
+
+		await this.app.fileManager.processFrontMatter(activeFile, (fm) => {
+			fm[noteIdKey] = noteId;
+
+			if (settings) {
+				if (settings.tags) {
+					fm.mowenTags = settings.tags;
+				}
+				if (typeof settings.auto_publish !== 'undefined') {
+					fm.mowenAutoPublish = settings.auto_publish;
+				}
+				if (settings.privacy) {
+					fm.mowenPrivacyType = settings.privacy.type;
+					if (settings.privacy.rule) {
+						fm.mowenPrivacyNoShare = settings.privacy.rule.noShare;
+						fm.mowenPrivacyExpireAt = settings.privacy.rule.expireAt;
+					}
+				}
+			}
+		});
+	}
+
+	/**
+	 * 从 frontmatter 加载已保存的发布设置
+	 */
+	async getSettingsFromFrontmatter(): Promise<Partial<PublishContextSettings>> {
+		const activeFile = this.app.workspace.getActiveFile();
+		if (!activeFile) return {};
+
+		const fileCache = this.app.metadataCache.getFileCache(activeFile);
+		const frontmatterObj: Record<string, unknown> = fileCache?.frontmatter || {};
+		
+		const loadedSettings: Partial<PublishContextSettings> = {};
+		if (frontmatterObj.mowenTags) {
+			loadedSettings.tags = String(frontmatterObj.mowenTags);
+		}
+		if (typeof frontmatterObj.mowenAutoPublish !== 'undefined') {
+			loadedSettings.auto_publish = Boolean(frontmatterObj.mowenAutoPublish);
+		}
+		if (frontmatterObj.mowenPrivacyType) {
+			loadedSettings.privacy = {
+				type: String(frontmatterObj.mowenPrivacyType) as 'private' | 'public' | 'rule',
+				rule: {
+					noShare: Boolean(frontmatterObj.mowenPrivacyNoShare),
+					expireAt: Number(frontmatterObj.mowenPrivacyExpireAt) || 0,
+				}
+			};
+		}
+		return loadedSettings;
+	}
+
+	/**
+	 * 从文件获取标题
+	 */
+	async getTitleFromFile(file: TFile): Promise<string> {
+		const titleKey = this.settings.titleKey;
+		if (!titleKey) {
+			return file.basename;
+		}
+
+		const fileCache = this.app.metadataCache.getFileCache(file);
+		const frontmatterObj: Record<string, unknown> = fileCache?.frontmatter || {};
+		
+		if (frontmatterObj[titleKey]) {
+			return String(frontmatterObj[titleKey]);
+		}
+
+		return file.basename;
+	}
+
+	/**
+	 * 获取当前活动文件的 frontmatter 对象
+	 */
+	getFrontmatterFromCache(): Record<string, unknown> {
+		const activeFile = this.app.workspace.getActiveFile();
+		if (!activeFile) return {};
+
+		const fileCache = this.app.metadataCache.getFileCache(activeFile);
+		return fileCache?.frontmatter || {};
+	}
+
+	/**
+	 * 获取需要检查的 noteId 键名列表
+	 */
+	private getNoteIdKeys(): string[] {
+		const customKey = this.settings.noteIdKey || 'noteId';
+		const defaultKey = 'noteId';
+
+		const keysToCheck: string[] = [customKey];
+		if (this.settings.enableLegacyNoteIdFallback && customKey !== defaultKey) {
+			keysToCheck.push(defaultKey);
+		}
+
+		return keysToCheck;
+	}
+}

--- a/src/services/TagService.ts
+++ b/src/services/TagService.ts
@@ -1,31 +1,32 @@
-import { markdownTagsToNoteAtomTags } from '../api';
-
 /**
  * 标签服务类
  * 提供标签合并等通用标签处理方法
+ * 
+ * 修复 #29: 简化参数，移除重复的 defaultTag/defaultTagsStr 参数
  */
+
+import { markdownTagsToNoteAtomTags } from '../api';
+
 export class TagService {
 	/**
 	 * 合并全局标签、默认标签和笔记标签
 	 * @param globalTagsStr - 全局标签字符串（逗号分隔）
-	 * @param defaultTagsStr - 默认标签字符串（逗号分隔）
+	 * @param defaultTag - 默认标签（同时用于 markdownTagsToNoteAtomTags 和作为默认标签）
 	 * @param content - 笔记内容（用于提取笔记标签）
-	 * @param defaultTag - 默认标签（用于 markdownTagsToNoteAtomTags）
 	 * @returns 合并后的标签字符串（逗号分隔）
 	 */
 	static mergeTags(
 		globalTagsStr: string | undefined,
-		defaultTagsStr: string | undefined,
-		content: string,
-		defaultTag: string
+		defaultTag: string | undefined,
+		content: string
 	): string {
 		const globalTags = globalTagsStr
 			? globalTagsStr.split(',').map((t) => t.trim()).filter(Boolean)
 			: [];
-		const defaultTags = defaultTagsStr
-			? defaultTagsStr.split(',').map((t) => t.trim()).filter(Boolean)
+		const defaultTags = defaultTag
+			? defaultTag.split(',').map((t) => t.trim()).filter(Boolean)
 			: [];
-		const noteTags = markdownTagsToNoteAtomTags(content, defaultTag).tags || [];
+		const noteTags = markdownTagsToNoteAtomTags(content, defaultTag || 'Obsidian').tags || [];
 		const tagsArr = Array.from(new Set([...defaultTags, ...globalTags, ...noteTags]));
 		return tagsArr.join(',');
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,7 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import MowenPlugin from "./main";
+import { checkApiKeyHealth } from "./api";
+import { checkAIServiceHealth } from "./ai";
 
 // 定义 LLM 设置的接口
 export interface LLMSettings {
@@ -79,17 +81,35 @@ export class MowenSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('API key')
-      .setDesc('请输入你的墨问 API key')
+      .setDesc('请输入你的墨问 API key。注意：API Key 将以明文存储在本地，请勿在不信任的环境中使用。')
       .addText(text => {
         text.inputEl.type = 'password';
         text
-          .setPlaceholder('Enter your API key')
+          .setPlaceholder('输入你的 API key')
           .setValue(this.plugin.settings.apiKey)
           .onChange(async (value) => {
             this.plugin.settings.apiKey = value;
             await this.plugin.saveSettings();
           });
-      });
+      })
+      .addButton(btn => btn
+        .setButtonText('验证')
+        .onClick(async () => {
+          btn.setButtonText('验证中...');
+          btn.setDisabled(true);
+          const result = await checkApiKeyHealth(this.plugin.settings.apiKey);
+          btn.setButtonText('验证');
+          btn.setDisabled(false);
+          if (result.valid) {
+            // 使用动态 import 避免 Notice 循环
+            const { Notice } = await import('obsidian');
+            new Notice('API Key 验证通过');
+          } else {
+            const { Notice } = await import('obsidian');
+            new Notice('API Key 验证失败: ' + (result.error?.getUserMessage().title || '未知错误'));
+          }
+        })
+      );
 
     new Setting(containerEl)
       .setName('笔记ID键名')
@@ -258,7 +278,7 @@ export class MowenSettingTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName('API key')
+      .setName('AI API key')
       .setDesc('请输入所选 AI 服务商的 API key')
       .addText(text => {
         text.inputEl.type = 'password';
@@ -269,7 +289,23 @@ export class MowenSettingTab extends PluginSettingTab {
             this.plugin.settings.llmSettings.apiKey = value;
             await this.plugin.saveSettings();
           });
-      });
+      })
+      .addButton(btn => btn
+        .setButtonText('验证')
+        .onClick(async () => {
+          btn.setButtonText('验证中...');
+          btn.setDisabled(true);
+          const result = await checkAIServiceHealth(this.plugin.settings);
+          btn.setButtonText('验证');
+          btn.setDisabled(false);
+          const { Notice } = await import('obsidian');
+          if (result.valid) {
+            new Notice('AI API Key 验证通过');
+          } else {
+            new Notice('AI API Key 验证失败: ' + (result.error?.getUserMessage().title || '未知错误'));
+          }
+        })
+      );
 
     new Setting(containerEl)
       .setName('模型名称')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,48 @@
+/**
+ * 项目通用类型定义
+ * 集中管理所有共享的类型接口，替代散落各处的 any
+ */
+
+import { NoteAtomMark } from '../api';
+
+/** 发布隐私设置 */
+export interface PublishPrivacySettings {
+	type: 'private' | 'public' | 'rule';
+	rule?: {
+		noShare?: boolean;
+		expireAt?: number;
+	};
+}
+
+/** 发布时的完整设置对象 */
+export interface PublishContextSettings {
+	section: number;
+	privacy: PublishPrivacySettings;
+	tags?: string;
+	auto_publish?: boolean;
+}
+
+/** Modal onSubmit 回调的参数类型 */
+export interface ModalSubmitParams {
+	title: string;
+	tags: string;
+	autoPublish: boolean;
+	settings: PublishContextSettings;
+	summary: string | null;
+}
+
+/** NoteAtom 文本节点（带 marks） */
+export interface NoteAtomTextNode {
+	type: 'text';
+	text: string;
+	marks?: NoteAtomMark[];
+}
+
+/** NoteAtom 节点（通用） */
+export interface NoteAtomNode {
+	type: string;
+	content?: NoteAtomNode[];
+	text?: string;
+	marks?: NoteAtomMark[];
+	attrs?: Record<string, unknown>;
+}

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -18,7 +18,8 @@ export enum MowenErrorCode {
   API_UNAUTHORIZED = 'API_UNAUTHORIZED',        // 401 - API Key 无效
   API_FORBIDDEN = 'API_FORBIDDEN',              // 403 - 权限不足
   API_NOT_FOUND = 'API_NOT_FOUND',              // 404 - 资源不存在
-  API_RATE_LIMIT = 'API_RATE_LIMIT',            // 429 - 请求频率限制
+  API_RATE_LIMIT = 'API_RATE_LIMIT',            // 429 - 请求频率限制（限频）
+  API_QUOTA_EXCEEDED = 'API_QUOTA_EXCEEDED',  // 403 - 配额不足（Quota）
   API_SERVER_ERROR = 'API_SERVER_ERROR',        // 500-599 - 服务器错误
   API_INVALID_RESPONSE = 'API_INVALID_RESPONSE', // 返回数据格式错误
   API_BUSINESS_ERROR = 'API_BUSINESS_ERROR',    // 业务逻辑错误（如发布失败）
@@ -72,8 +73,13 @@ const ERROR_MESSAGES: Record<MowenErrorCode, { title: string; detail: string; ac
   },
   [MowenErrorCode.API_RATE_LIMIT]: {
     title: '请求过于频繁',
-    detail: '您的请求次数已达到限制',
-    action: '请等待几分钟后再试'
+    detail: '您的请求速度过快，触发了限频',
+    action: '请等待几秒钟后再试'
+  },
+  [MowenErrorCode.API_QUOTA_EXCEEDED]: {
+    title: '配额已用完',
+    detail: '今日 API 调用次数已达上限',
+    action: '请明天再试，或联系客服提升配额'
   },
   [MowenErrorCode.API_SERVER_ERROR]: {
     title: '服务器错误',
@@ -172,13 +178,20 @@ export function classifyApiError(status: number, responseBody: any, originalErro
     return new MowenError(MowenErrorCode.API_UNAUTHORIZED, responseBody?.msg || '认证失败', originalError, status);
   }
   if (status === 403) {
-    return new MowenError(MowenErrorCode.API_FORBIDDEN, responseBody?.msg || '无权限', originalError, status);
+    // 墨问官方文档：403 可能是 PERM/RISKY/BLOCKED/Quota
+    // 根据 reason 字段区分
+    const reason = responseBody?.reason || '';
+    if (reason === 'Quota') {
+      return new MowenError(MowenErrorCode.API_QUOTA_EXCEEDED, responseBody?.message || '配额不足', originalError, status);
+    }
+    return new MowenError(MowenErrorCode.API_FORBIDDEN, responseBody?.msg || responseBody?.message || '无权限', originalError, status);
   }
   if (status === 404) {
     return new MowenError(MowenErrorCode.API_NOT_FOUND, responseBody?.msg || '资源不存在', originalError, status);
   }
   if (status === 429) {
-    return new MowenError(MowenErrorCode.API_RATE_LIMIT, responseBody?.msg || '请求频率限制', originalError, status);
+    // 墨问官方文档：429 对应 RATELIMIT reason
+    return new MowenError(MowenErrorCode.API_RATE_LIMIT, responseBody?.message || '请求频率限制', originalError, status);
   }
   if (status >= 500 && status < 600) {
     return new MowenError(MowenErrorCode.API_SERVER_ERROR, responseBody?.msg || `服务器错误(${status})`, originalError, status);
@@ -234,6 +247,7 @@ export const DEFAULT_RETRY_CONFIG: RetryConfig = {
   initialDelayMs: 1000,
   maxDelayMs: 10000,
   backoffMultiplier: 2,
+  // 重试配置 - API_QUOTA_EXCEEDED 不可重试
   retryableErrors: [
     MowenErrorCode.NETWORK_TIMEOUT,
     MowenErrorCode.NETWORK_CONNECTION_FAILED,

--- a/styles.css
+++ b/styles.css
@@ -3,16 +3,19 @@
 This CSS file will be included with your plugin, and
 available in the app when your plugin is enabled.
 
-If your plugin does not need CSS, delete this file.
-
 */
 
-/* 你可以在这里自定义弹窗、按钮等样式。例如： */
-
+/* 墨问发布弹窗样式 */
 .mowen-publish-modal .setting-item {
   margin-bottom: 1em;
 }
 
 .mowen-publish-modal h2 {
   color: var(--text-accent);
+}
+
+/* 修复 #26: 错误提示使用 CSS 变量，兼容暗色/亮色主题 */
+.mowen-error-container {
+  color: var(--text-error, #e74c3c);
+  margin-bottom: 10px;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
-    "target": "ES6",
+    "target": "ES2020",
     "allowJs": true,
     "noImplicitAny": true,
     "moduleResolution": "node",


### PR DESCRIPTION
## 概述

基于墨问官方 OpenAPI 文档的深度审查，对插件进行全面重构和 API 合规性修复，解决图片上传重复/不显示、隐私设置失效等关键问题。

## 架构重构

- main.ts 从 ~1115 行精简到 ~260 行，拆分为 4 个独立模块：
  - `src/converter/MarkdownConverter.ts` — Markdown→NoteAtom 转换器
  - `src/modals/MowenPublishModal.ts` — 发布弹窗
  - `src/services/FrontmatterService.ts` — Frontmatter 操作服务
  - `src/types/index.ts` — 统一类型定义

## API 接口修复（入参/出参变化）

### 1. 笔记创建/编辑请求体按官方文档拆分
- **创建** `POST /note/create`：`{ body, settings: { autoPublish, tags } }`，不再混入 privacy/section
- **编辑** `POST /note/edit`：`{ noteId, body }`，不再发送 settings
- **隐私设置** 独立调用 `POST /note/set`：`{ noteId, section: 1, settings: { privacy: { type, rule: { noShare, expireAt: String() } } } }`

### 2. 修复 deliverFile 返回数据层级不匹配
- **修复前**：`{ success: true, data: result.file }` → `uploadRes.data.file` 为 `undefined`
- **修复后**：`{ success: true, data: { file: result.file } }` → `uploadRes.data.file.fileId` 正确取值
- **这是图片不显示的根本原因**：uuid 始终为空导致 image 节点变成纯文本 fallback

### 3. getUploadAuthorization 新增 fileName 参数
- 入参：`{ fileType, fileName? }`，按官方文档传入文件名

### 4. deliverFile FormData 新增 x:file_name
- 修复 Issue #15：PDF 等文件名缺失

### 5. updateNotePrivacy expireAt 类型修正
- `number` → `string`（`String()` 转换），匹配官方类型定义

### 6. 隐私设置调用时机修正
- **修复前**：`privacy.type !== "private"` → 选择"私有"时不调用 → 笔记默认公开
- **修复后**：`privacy.type !== "public"` → 只在非默认公开时调用

## 图片上传修复

- 去掉两遍扫描（preUploadImages + processEmbedOrLink），改为一遍扫描 + uploadCache
- 同一图片只上传一次，避免重复调用上传接口

## 错误处理增强

- 新增 `API_QUOTA_EXCEEDED` 错误码，区分限频（429 RATELIMIT）和配额耗尽（403 Quota）
- 403 响应按 `reason` 字段区分：`Quota` → 配额不足，其他 → 权限不足
- 429 响应取 `message` 字段（匹配官方错误码结构）

## 类型安全

- `MarkType`：`bold | link | highlight | italic | strike` → `bold | link | highlight`（墨问只支持这三种）
- `NoteAtomMark.type`：移除 `| string`，严格类型约束
- `NoteAtomMark.attrs` / `NoteAtomNode.attrs`：`Record<string, any>` → `Record<string, unknown>`
- `FileUploadResponse.data.file`：扩展完整字段定义

## NoteAtom 兼容性修复

- 代码块类型：`code_block` → `codeblock`
- 斜体处理：`*italic*` → highlight（墨问不支持 italic marks）
- 引用块：支持富文本（processInlineFormatting）

## 其他

- AI 健康检查改为轻量级模型列表 API（不消耗生成额度）
- AI 超时改用 AbortController（防泄漏）
- batchUploadFiles 改为 Promise.allSettled 并发上传
- 版本：0.0.26 → 0.0.27
- TypeScript target：ES6 → ES2020
- CI/CD：迁移到 softprops/action-gh-release@v2, Node 18
