### PR TITLE
fix: 修复发布弹窗默认私有不生效的问题

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "publish-note-to-mowen",
 	"name": "Publish Note to Mowen Note",
-	"version": "0.0.27",
+	"version": "0.0.28",
 	"minAppVersion": "0.15.0",
 	"description": "Publish note to Mowen note mini program.",
 	"author": "ziyou",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-mowen-plugin",
-	"version": "0.0.27",
+	"version": "0.0.28",
 	"description": "This is a mowen plugin for Obsidian (https://obsidian.md)",
 	"main": "main.js",
 	"scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -40,7 +40,7 @@ export interface NoteAtomNode {
  * 发布隐私设置接口
  */
 export interface PublishPrivacy {
-  type: 'private' | 'public' | 'rule';
+  type:  'public' | 'private' | 'rule';
   rule?: {
     noShare?: boolean;
     expireAt?: number;
@@ -302,7 +302,8 @@ async function updateNotePrivacy(
   const privacyPayload: Record<string, unknown> = {
     type: privacy.type,
   };
-  if (privacy.rule) {
+  // 仅当 type 为 'rule' 时才发送 rule 字段，避免 API 误解 expireAt: '0' 导致隐私不生效
+  if (privacy.type === 'rule' && privacy.rule) {
     privacyPayload.rule = {
       noShare: privacy.rule.noShare ?? false,
       // 官方文档 expireAt 类型为 string（时间戳秒的字符串形式）

--- a/src/modals/MowenPublishModal.ts
+++ b/src/modals/MowenPublishModal.ts
@@ -239,8 +239,8 @@ class MowenPublishModal extends Modal {
 				.setName('隐私类型')
 				.setDesc('设置笔记的隐私类型')
 				.addDropdown(drop => {
-					drop.addOption('private', '私有');
 					drop.addOption('public', '公开');
+					drop.addOption('private', '私有');
 					drop.addOption('rule', '规则');
 					drop.setValue(this.privacy);
 					drop.onChange(value => {
@@ -310,10 +310,12 @@ class MowenPublishModal extends Modal {
 									section: this.section,
 									privacy: {
 										type: this.privacy as 'private' | 'public' | 'rule',
-										rule: {
-											noShare: this.privacy === 'rule' ? this.noShare : undefined,
-											expireAt: this.privacy === 'rule' ? this.expireAt : undefined
-										}
+										...(this.privacy === 'rule' ? {
+											rule: {
+												noShare: this.noShare,
+												expireAt: this.expireAt
+											}
+										} : {})
 									}
 								},
 								summary: this.summary


### PR DESCRIPTION
## 问题描述
发布弹窗中打开隐私设置开关后，默认的私有选项不生效，必须手动重新点击才能生效。

## 根因分析
1. **Modal 提交时**：`rule` 对象无论 `privacy.type` 是什么都会被包含。当 `type: 'private'` 时，`rule: { noShare: undefined, expireAt: undefined }` 被传给 API。
2. **API 发送时**：`updateNotePrivacy` 中 `if (privacy.rule)` 对含 undefined 属性的对象判断为 truthy，导致 `rule: { noShare: false, expireAt: '0' }` 被发送。`expireAt: '0'` 被 API 解析为 epoch 0（已过期），使隐私设置失效。

## 修复内容
- Modal 提交时仅在 `privacy.type === 'rule'` 时才包含 `rule` 字段
- API 层增加 `privacy.type === 'rule'` 前置条件，确保非 rule 类型不发送多余的 rule 数据
- 调整隐私类型下拉框选项顺序为公开、私有、规则
- 版本升级至 0.0.28