### PR TITLE
feat: Markdown 转换优化 - 列表符号/公网图片/标题空行

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "publish-note-to-mowen",
 	"name": "Publish Note to Mowen Note",
-	"version": "0.0.29",
+	"version": "0.0.30",
 	"minAppVersion": "0.15.0",
 	"description": "Publish note to Mowen note mini program.",
 	"author": "ziyou",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-mowen-plugin",
-	"version": "0.0.29",
+	"version": "0.0.30",
 	"description": "This is a mowen plugin for Obsidian (https://obsidian.md)",
 	"main": "main.js",
 	"scripts": {

--- a/src/converter/handlers/ListHandler.ts
+++ b/src/converter/handlers/ListHandler.ts
@@ -34,7 +34,7 @@ export class ListHandler implements BlockHandler {
 				{
 					type: 'paragraph',
 					content: [
-						{ type: 'text', text: listMatch[2] + ' ' },
+						{ type: 'text', text: '• ' },
 						...listContent
 					]
 				},


### PR DESCRIPTION
## 📋 本次优化内容

### P1 核心优化
- **列表符号转换**: `-`/`*`/`+` → `•`，墨问小程序显示更美观
- **公网图片支持**: 自动下载公网图片并上传到墨问 OSS，绕过防盗链
- **标题格式优化**: 标题后自动加空行，避免墨问渲染粘连

### 版本变更
- 0.0.29 → 0.0.30

## 🧪 测试建议
1. 测试普通列表发布到墨问，验证符号是否正确显示为 •
2. 测试包含公网图片（如 unsplash）的笔记发布
3. 测试多级标题的渲染效果

## 📝 相关提交
- `dee46e9` feat: 列表符号转换为 • (v0.0.30)
- `ad39ed2` feat: 支持公网图片下载上传，标题后加空行，OSS防盗链绕过