### PR TITLE
refactor: 使用 /my/profile 接口验证 API Key

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -673,49 +673,49 @@ export function getFileTypeName(fileType: number): string {
 
 /**
  * 检查 API Key 是否有效（健康检查）
- * 通过调用一个轻量级 API 来验证
+ * 通过调用 /my/profile 接口获取用户信息来验证
  */
 export async function checkApiKeyHealth(apiKey: string): Promise<{ valid: boolean; error?: MowenError }> {
   if (!apiKey || apiKey.trim() === '') {
-    return { 
-      valid: false, 
-      error: new MowenError(MowenErrorCode.CONFIG_API_KEY_MISSING) 
+    return {
+      valid: false,
+      error: new MowenError(MowenErrorCode.CONFIG_API_KEY_MISSING)
     };
   }
-  
+
   try {
-    // 尝试获取上传授权作为健康检查（轻量级操作）
+    // 调用用户信息接口验证 API Key
     const response = await safeRequest(
-      `${baseUrl}/upload/prepare`,
+      `${baseUrl}/my/profile`,
       "POST",
       {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${apiKey}`,
       },
-      JSON.stringify({ fileType: 1 }),
+      "{}",
       10000 // 10秒超时
     );
-    
+
     if (response.status === 401) {
-      return { 
-        valid: false, 
-        error: new MowenError(MowenErrorCode.API_UNAUTHORIZED, 'API Key 无效或已过期') 
+      return {
+        valid: false,
+        error: new MowenError(MowenErrorCode.API_UNAUTHORIZED, 'API Key 无效或已过期')
       };
     }
-    
+
     if (response.status === 200) {
       return { valid: true };
     }
-    
+
     // 其他状态码
-    return { 
-      valid: false, 
-      error: classifyApiError(response.status, response.json, undefined) 
+    return {
+      valid: false,
+      error: classifyApiError(response.status, response.json, undefined)
     };
   } catch (error: any) {
-    return { 
-      valid: false, 
-      error: error instanceof MowenError ? error : classifyNetworkError(error as Error) 
+    return {
+      valid: false,
+      error: error instanceof MowenError ? error : classifyNetworkError(error as Error)
     };
   }
 }


### PR DESCRIPTION
## Summary
- 将 API Key 健康检查接口从 `/upload/prepare` 改为 `/my/profile`
- 语义更清晰，直接获取用户信息确认身份
- 无副作用，不触发上传流程
- 不需要参数，只需空请求体

## Test plan
- 在设置页面点击"验证"按钮，确认 API Key 验证功能正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)