### PR TITLE
docs: 重构 CLAUDE.md 为索引手册

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,113 +1,59 @@
-# Claude Code 开发注意事项
+# Obsidian 墨问插件开发指南
 
-本文档记录使用 Claude Code 开发 Obsidian 墨问插件时遇到的各种坑，供后续开发参考。
+> Claude Code Agent 导航索引手册，保持在 200 行以内。详细内容见 docs 目录。
 
 ---
 
-## Obsidian 插件开发坑
+## 项目概览
 
-### 1. 禁止使用动态 import
+- **插件名称**: Publish Note to Mowen Note
+- **插件 ID**: `publish-note-to-mowen`
+- **墨问 API 文档**: https://mowen.apifox.cn/llms.txt
 
-**坑点**：Obsidian 插件运行时不支持动态 import ES 模块。
+---
 
-**错误示例**：
-```typescript
-const { Notice } = await import('obsidian'); // 会报错
+## 文档索引
+
+| 文档 | 说明 |
+|------|------|
+| [docs/api-key-validation-issues.md](docs/api-key-validation-issues.md) | API Key 验证按钮问题总结 |
+| [docs/obsidian-plugin-pitfalls.md](docs/obsidian-plugin-pitfalls.md) | Obsidian 插件开发常见坑 |
+| [docs/git-github-pitfalls.md](docs/git-github-pitfalls.md) | Git/GitHub 操作常见坑 |
+| [docs/dev-workflow.md](docs/dev-workflow.md) | 开发流程指南 |
+
+---
+
+## 关键约束（必读）
+
+### Obsidian 插件开发
+
+1. **禁止动态 import** - 必须静态导入 `import { X } from "obsidian"`
+2. **Tag 格式统一** - 使用 `0.0.XX`（无 v 前缀），与历史版本保持一致
+3. **versions.json 必须包含在 release** - 缺少会导致安装失败
+
+### 墨问 API
+
+- **只使用官方文档确认存在的接口** - 查看 https://mowen.apifox.cn/llms.txt
+- 可用接口: `/upload/prepare`, `/note/create`, `/note/edit`, `/note/set`
+
+---
+
+## 发布流程（简版）
+
+1. 更新版本号: manifest.json, package.json, versions.json
+2. 创建分支 → 提交 → PR → 合并到 main
+3. 创建 tag: `git tag 0.0.XX origin/main && git push origin 0.0.XX`
+4. 等待 workflow，检查 release assets
+
+---
+
+## 文件结构
+
 ```
-
-**报错信息**：
+src/
+├── api.ts          # 墨问 API 调用
+├── settings.ts     # 设置页面
+├── main.ts         # 插件入口
+├── converter/      # Markdown 转换器
+└── utils/          # 工具函数
 ```
-Uncaught (in promise) TypeError: Failed to resolve module specifier 'obsidian'
-```
-
-**正确做法**：
-```typescript
-import { Notice } from "obsidian"; // 静态导入
-```
-
----
-
-### 2. Release Tag 格式必须统一
-
-**坑点**：Obsidian 插件商店对 tag 格式有要求，必须与历史版本格式一致。
-
-**问题**：本项目历史版本使用 `0.0.X`（无 v 前缀），如果新版本使用 `v0.0.X`（有 v 前缀），会导致插件无法安装。
-
-**正确做法**：
-- 创建 tag 时使用 `git tag 0.0.33`（无 v 前缀）
-- 检查历史版本 tag 格式，保持一致
-
----
-
-### 3. versions.json 必须包含在 Release 中
-
-**坑点**：Obsidian 插件商店依赖 versions.json 追踪版本兼容性，缺少该文件会导致安装失败。
-
-**正确做法**：
-- workflow 中打包 versions.json 到 zip
-- release assets 包含 versions.json
-- 每次发布新版本时更新 versions.json
-
----
-
-### 4. 只使用官方文档确认存在的 API
-
-**坑点**：墨问开放平台文档中有些 schema 定义（如 MyProfileReply）但没有实际的 API endpoint。
-
-**问题**：调用 `/my/profile` 接口会失败，因为该接口不存在。
-
-**正确做法**：
-- 只使用官方文档明确列出的接口
-- 查看 https://mowen.apifox.cn/llms.txt 确认接口是否存在
-- 墨问开放平台可用接口：`/upload/prepare`、`/note/create`、`/note/edit`、`/note/set` 等
-
----
-
-## Git/GitHub 坑
-
-### 1. Worktree 冲突
-
-**坑点**：使用 git worktree 时，main 分支可能被其他 worktree 占用，无法 checkout。
-
-**报错信息**：
-```
-fatal: 'main' is already used by worktree at '/path/to/other/worktree'
-```
-
-**正确做法**：
-- 创建 feature/release 分支进行开发
-- 通过 PR 合并到 main
-- 使用 `git tag <version> origin/main` 创建 tag
-
----
-
-### 2. gh pr merge 在 worktree 环境可能失败
-
-**坑点**：`gh pr merge --merge --delete-branch` 在 worktree 环境可能因为 git 操作失败。
-
-**正确做法**：
-- 使用 `gh pr merge --merge` (不带 --delete-branch)
-- 或通过 GitHub Web UI 合并
-
----
-
-## 开发流程建议
-
-### 发布新版本流程
-
-1. 修改代码，本地测试
-2. 更新版本号：
-   - manifest.json
-   - package.json
-   - versions.json（添加新版本记录）
-3. 创建分支，提交代码
-4. 创建 PR 并合并到 main
-5. 创建 tag（无 v 前缀）：`git tag 0.0.XX origin/main`
-6. 推送 tag：`git push origin 0.0.XX`
-7. 等待 workflow 完成，检查 release assets
-
-### 验证 API 接口流程
-
-1. 查看 https://mowen.apifox.cn/llms.txt
-2. 确认接口在文档中明确列出（有完整路径和方法）
-3. 只使用确认存在的接口

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -1,0 +1,96 @@
+# 开发流程指南
+
+本文档记录 Obsidian 墨问插件的开发流程和操作指南。
+
+---
+
+## 发布新版本流程
+
+### 1. 修改代码
+- 本地开发和测试
+- 确保代码正确运行
+
+### 2. 更新版本号
+需要修改以下文件：
+- `manifest.json` - `"version": "0.0.XX"`
+- `package.json` - `"version": "0.0.XX"`
+- `versions.json` - 添加 `"0.0.XX": "0.15.0"`
+
+### 3. 提交代码
+```bash
+git checkout -b release/v0.0.XX
+git add manifest.json package.json versions.json
+git commit -m "chore: bump version to 0.0.XX"
+git push -u origin release/v0.0.XX
+```
+
+### 4. 创建 PR 并合并
+```bash
+gh pr create --title "chore: bump version to 0.0.XX" --base main
+gh pr merge <PR号> --merge
+```
+
+### 5. 创建 Tag（无 v 前缀）
+```bash
+git fetch origin
+git tag 0.0.XX origin/main
+git push origin 0.0.XX
+```
+
+### 6. 等待 Workflow 完成
+```bash
+gh run list --limit 1
+gh release view 0.0.XX
+```
+
+### 7. 检查 Release Assets
+确保包含：
+- main.js
+- manifest.json
+- styles.css
+- versions.json
+- obsidian-mowen-plugin.zip
+
+---
+
+## 验证 API 接口流程
+
+### 1. 查看官方文档
+访问 https://mowen.apifox.cn/llms.txt
+
+### 2. 确认接口存在
+检查接口是否有完整路径和方法，不只是 schema 定义。
+
+### 3. 墨问开放平台可用接口
+| 接口 | 方法 | 说明 |
+|------|------|------|
+| `/upload/prepare` | POST | 获取上传授权 |
+| `/note/create` | POST | 创建笔记 |
+| `/note/edit` | POST | 编辑笔记 |
+| `/note/set` | POST | 设置笔记属性 |
+| `/upload/via-url` | POST | URL 上传文件 |
+
+---
+
+## 修复 Bug 流程
+
+### 1. 创建修复分支
+```bash
+git checkout -b fix/<bug-name>
+```
+
+### 2. 修改代码并提交
+```bash
+git add <files>
+git commit -m "fix: 问题描述"
+git push -u origin fix/<bug-name>
+```
+
+### 3. 创建 PR 并合并
+```bash
+gh pr create --title "fix: 问题描述" --base main
+gh pr merge <PR号> --merge
+```
+
+### 4. 如果需要发布新版本
+按上述发布流程操作。

--- a/docs/git-github-pitfalls.md
+++ b/docs/git-github-pitfalls.md
@@ -1,0 +1,63 @@
+# Git/GitHub 操作常见坑
+
+本文档记录 Git 和 GitHub CLI 操作过程中遇到的常见问题及解决方案。
+
+---
+
+## 1. Worktree 冲突
+
+### 坑点
+使用 git worktree 时，main 分支可能被其他 worktree 占用，无法 checkout。
+
+### 报错信息
+```
+fatal: 'main' is already used by worktree at '/path/to/other/worktree'
+```
+
+### 正确做法
+- 创建 feature/release 分支进行开发
+- 通过 PR 合并到 main
+- 使用 `git tag <version> origin/main` 创建 tag
+
+---
+
+## 2. gh pr merge 在 worktree 环境可能失败
+
+### 坑点
+`gh pr merge --merge --delete-branch` 在 worktree 环境可能因为 git 操作失败。
+
+### 正确做法
+- 使用 `gh pr merge --merge` (不带 --delete-branch)
+- 或通过 GitHub Web UI 合并
+
+---
+
+## 3. 删除远程 Tag
+
+### 命令
+```bash
+# 删除本地 tag
+git tag -d v0.0.31
+
+# 删除远程 tag
+git push origin --delete v0.0.31
+```
+
+---
+
+## 4. 删除 Release
+
+### 命令
+```bash
+gh release delete v0.0.31 --yes
+```
+
+---
+
+## 5. 查看 Release Assets
+
+### 命令
+```bash
+gh release view 0.0.32
+gh release download 0.0.32 --dir /tmp/check
+```

--- a/docs/obsidian-plugin-pitfalls.md
+++ b/docs/obsidian-plugin-pitfalls.md
@@ -1,0 +1,81 @@
+# Obsidian 插件开发常见坑
+
+本文档记录 Obsidian 插件开发过程中遇到的常见问题及解决方案。
+
+---
+
+## 1. 禁止使用动态 import
+
+### 坑点
+Obsidian 插件运行时不支持动态 import ES 模块。
+
+### 错误示例
+```typescript
+const { Notice } = await import('obsidian'); // 会报错
+```
+
+### 报错信息
+```
+Uncaught (in promise) TypeError: Failed to resolve module specifier 'obsidian'
+```
+
+### 正确做法
+```typescript
+import { Notice } from "obsidian"; // 静态导入
+```
+
+---
+
+## 2. Release Tag 格式必须统一
+
+### 坑点
+Obsidian 插件商店对 tag 格式有要求，必须与历史版本格式一致。
+
+### 问题
+本项目历史版本使用 `0.0.X`（无 v 前缀），如果新版本使用 `v0.0.X`（有 v 前缀），会导致插件无法安装。
+
+### 正确做法
+- 创建 tag 时使用 `git tag 0.0.33`（无 v 前缀）
+- 检查历史版本 tag 格式，保持一致
+
+---
+
+## 3. versions.json 必须包含在 Release 中
+
+### 坑点
+Obsidian 插件商店依赖 versions.json 追踪版本兼容性，缺少该文件会导致安装失败。
+
+### 正确做法
+- workflow 中打包 versions.json 到 zip
+- release assets 包含 versions.json
+- 每次发布新版本时更新 versions.json
+
+---
+
+## 4. Notice 显示时间
+
+### 坑点
+移动端 Notice 默认显示时间较短（约 3-5 秒），可能来不及看到。
+
+### 建议
+```typescript
+new Notice('提示信息', 8000); // 显示 8 秒
+```
+
+---
+
+## 5. requestUrl 超时处理
+
+### 坑点
+Obsidian 的 `requestUrl` 不支持 `AbortController`，需要使用内置的 `timeout` 参数。
+
+### 正确做法
+```typescript
+requestUrl({
+  url,
+  method,
+  headers,
+  body,
+  timeout: 10000 // 毫秒
+});
+```


### PR DESCRIPTION
## Summary
- CLAUDE.md 改为简洁索引（58 行），保持在 200 行以内
- 详细内容分散到 docs 目录下的独立文件

## 新增文档
| 文档 | 说明 |
|------|------|
| docs/obsidian-plugin-pitfalls.md | Obsidian 开发常见坑 |
| docs/git-github-pitfalls.md | Git/GitHub 操作常见坑 |
| docs/dev-workflow.md | 开发流程指南 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)